### PR TITLE
Avoid n+1 queries when getting ActiveStorage blobs

### DIFF
--- a/app/controllers/albums_controller.rb
+++ b/app/controllers/albums_controller.rb
@@ -9,7 +9,7 @@ class AlbumsController < ApplicationController
   def index
     authorize Album
     @albums = apply_scopes(policy_scope(Album))
-              .includes(:album_artists, :album_labels, image: %i[image_attachment image_blob image_type])
+              .includes(:album_artists, :album_labels, image: [{ image_attachment: :blob }, :image_type])
               .paginate(page: params[:page], per_page: params[:per_page])
     add_pagination_headers(@albums)
   end

--- a/app/controllers/artists_controller.rb
+++ b/app/controllers/artists_controller.rb
@@ -6,7 +6,7 @@ class ArtistsController < ApplicationController
   def index
     authorize Artist
     @artists = apply_scopes(policy_scope(Artist))
-               .includes(image: %i[image_attachment image_blob image_type])
+               .includes(image: [{ image_attachment: :blob }, :image_type])
                .paginate(page: params[:page], per_page: params[:per_page])
     add_pagination_headers(@artists)
   end


### PR DESCRIPTION
This reduces the total request time for albums and artists drastically (up to 3x speedup, when testing with our production database).