### PR TITLE
Configure new cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,6 +18,11 @@ Layout/FirstHashElementIndentation:
 Layout/LineLength:
   Enabled: false
 
+Lint/RaiseException:
+  Enabled: true
+Lint/StructNewOverride:
+  Enabled: true
+
 Metrics/AbcSize:
   Enabled: false
 Metrics/BlockLength:


### PR DESCRIPTION
I checked the logs of the dependabot update before merging, but the warning about the new cops wasn't shown there. This PR adds their configuration.