### PR TITLE
Send not-found errors with modelname in plural

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -52,6 +52,6 @@ class ApplicationController < ActionController::API
   end
 
   def model_not_found(exc)
-    render json: { not_found: ["#{exc.model.downcase}.not-found"] }, status: :not_found
+    render json: { not_found: ["#{exc.model.pluralize.downcase}.not-found"] }, status: :not_found
   end
 end


### PR DESCRIPTION
Tiny fix.
We have these keys under the plural in [web](https://github.com/accentor/web/blob/70f09d2419866f87c0d95c52d94777aa51e6378c/src/locales/nl.json#L84), since the singular was already user to name the model in errors.