### PR TITLE
Don't include full backtrace of error in prod

### DIFF
--- a/app/models/rescan_runner.rb
+++ b/app/models/rescan_runner.rb
@@ -40,7 +40,8 @@ class RescanRunner < ApplicationRecord
         update(warning_text: "#{warning_text}File #{af.full_path} doesn't exist anymore.\n") unless af.check_self
       end
     rescue StandardError => e
-      update(error_text: "#{error_text}A really unexpected error occurred while processing: #{e.message}\n#{e.backtrace.join("\n")}\n")
+      backtrace = Rails.env.production? ? e.backtrace.first(5).join("\n") : e.backtrace.join("\n")
+      update(error_text: "#{error_text}A really unexpected error occurred while processing: #{e.message}\n#{backtrace}\n")
     ensure
       update(running: false, finished_at: DateTime.current)
     end
@@ -65,7 +66,8 @@ class RescanRunner < ApplicationRecord
             process_file(location, c, File.join(path, child))
             update(processed: processed + 1)
           rescue StandardError => e
-            update(error_text: "#{error_text}An error occurred while processing #{File.join(path, child)}: #{e.message}\n#{e.backtrace.join("\n")}\n")
+            backtrace = Rails.env.production? ? e.backtrace.first(5).join("\n") : e.backtrace.join("\n")
+            update(error_text: "#{error_text}An error occurred while processing #{File.join(path, child)}: #{e.message}\n#{backtrace}")
           end
         end
       end


### PR DESCRIPTION
<!--
Thanks for contributing to Accentor!
Make sure all GitHub actions (test & lint) will pass and fill out the template.

You can tag your PR with the relevant tags and request a review from someone of the team.
If any changes to your PR are necessary, we will ask for them through the review process.
 -->

## Description

Limit the lenght of the backtrace for RescanRunner errors in production

# How Has This Been Tested?
Tested locally to produce the correct errors in prod/dev env