### PR TITLE
Make storage definitions public for image permalinks

### DIFF
--- a/config/storage.yml
+++ b/config/storage.yml
@@ -1,10 +1,12 @@
 test:
   service: Disk
   root: <%= Rails.root.join("tmp/storage") %>
+  public: true
 
 local:
   service: Disk
   root: <%= Rails.root.join("storage") %>
+  public: true
 
 # Use rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
 # amazon:


### PR DESCRIPTION
This should improve caching behaviour.

Should fix #24.

No tests, but I did run locally.