### PR TITLE
Switch ruby setup in CI to action from ruby org

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,21 +18,10 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
     - uses: actions/checkout@v2.3.4
-    - name: Use ruby 2.7
-      uses: actions/setup-ruby@v1.1.2
+    - name: Setup ruby from /.ruby_version
+      uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.7.2
-    - name: Cache Ruby dependencies
-      uses: actions/cache@v2
-      with:
-        path: vendor/bundle
-        key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-gem-
-    - name: Install dependencies
-      run: |
-        bundle config set path vendor/bundle
-        bundle install --jobs 4 --retry 3
+        bundler-cache: true
     - name: Run tests
       env:
         CI: true
@@ -44,21 +33,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2.3.4
-    - name: Use ruby 2.7
-      uses: actions/setup-ruby@v1.1.2
+    - name: Setup ruby from /.ruby_version
+      uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.7.2
-    - name: Cache Ruby dependencies
-      uses: actions/cache@v2
-      with:
-        path: vendor/bundle
-        key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-gem-
-    - name: Install dependencies
-      run: |
-        bundle config set path vendor/bundle
-        bundle install --jobs 4 --retry 3
+        bundler-cache: true
     - name: Lint with rubocop
       env:
         RAILS_ENV: "test"


### PR DESCRIPTION
<!--
Thanks for contributing to Accentor!
Make sure all GitHub actions (test & lint) will pass and fill out the template.

You can tag your PR with the relevant tags and request a review from someone of the team.
If any changes to your PR are necessary, we will ask for them through the review process.
 -->

# Description

The action to setup ruby from the ruby org:
* Supports a lot more rby versions
* Handles bundler install and cache for dependencies
* Read the version from /.ruby_version, so our actions don't need to be updated when we update a ruby version
* (and is just as fast)