### PR TITLE
Check ffmpeg version and allow validation of ContentLengths

### DIFF
--- a/app/models/content_length.rb
+++ b/app/models/content_length.rb
@@ -31,8 +31,6 @@ class ContentLength < ApplicationRecord
         audio_file.delay(queue: :content_lengths_backlog).calc_audio_length(cc)
       end
     end
-
-    false
   end
 
   private

--- a/app/models/content_length.rb
+++ b/app/models/content_length.rb
@@ -3,6 +3,7 @@
 # Table name: content_lengths
 #
 #  id                  :bigint           not null, primary key
+#  ffmpeg_version      :string           not null
 #  length              :integer          not null
 #  audio_file_id       :bigint           not null
 #  codec_conversion_id :bigint           not null
@@ -15,4 +16,11 @@ class ContentLength < ApplicationRecord
   validates :audio_file, presence: true, uniqueness: { scope: :codec_conversion }
   validates :codec_conversion, presence: true
   validates :length, presence: true
+
+  before_save :set_ffmpeg_version
+  private
+
+  def set_ffmpeg_version
+    self.ffmpeg_version = Rails.application.config.FFMPEG_VERSION
+  end
 end

--- a/app/models/content_length.rb
+++ b/app/models/content_length.rb
@@ -27,7 +27,7 @@ class ContentLength < ApplicationRecord
     if audio_file.length > Rails.application.config.recalculate_content_length_if_longer_than ||
        audio_file.track.created_at.after?(Rails.application.config.recalculate_content_length_if_newer_than.call)
       CodecConversion.find_each do |cc|
-        audio_file.delay(queue: :content_lengths).calc_audio_length(cc)
+        audio_file.delay(queue: :content_lengths_backlog).calc_audio_length(cc)
       end
     end
 

--- a/app/models/content_length.rb
+++ b/app/models/content_length.rb
@@ -25,11 +25,10 @@ class ContentLength < ApplicationRecord
 
     destroy
 
-    if audio_file.length > Rails.application.config.recalculate_content_length_if_longer_than ||
-       audio_file.track.created_at.after?(Rails.application.config.recalculate_content_length_if_newer_than.call)
-      CodecConversion.find_each do |cc|
-        audio_file.delay(queue: :content_lengths_backlog).calc_audio_length(cc)
-      end
+    return unless Rails.application.config.recalculate_content_length_if.call audio_file
+
+    CodecConversion.find_each do |cc|
+      audio_file.delay(queue: :content_lengths_backlog).calc_audio_length(cc)
     end
   end
 

--- a/app/models/content_length.rb
+++ b/app/models/content_length.rb
@@ -22,6 +22,8 @@ class ContentLength < ApplicationRecord
   def check_ffmpeg_version
     return true if ffmpeg_version == Rails.application.config.FFMPEG_VERSION
 
+    destroy
+
     if audio_file.length > Rails.application.config.recalculate_content_length_if_longer_than ||
        audio_file.track.created_at.after?(Rails.application.config.recalculate_content_length_if_newer_than.call)
       CodecConversion.find_each do |cc|
@@ -29,7 +31,6 @@ class ContentLength < ApplicationRecord
       end
     end
 
-    destroy
     false
   end
 

--- a/app/models/content_length.rb
+++ b/app/models/content_length.rb
@@ -18,6 +18,14 @@ class ContentLength < ApplicationRecord
   validates :length, presence: true
 
   before_save :set_ffmpeg_version
+
+  def check_ffmpeg_version
+    return true if ffmpeg_version == Rails.application.config.FFMPEG_VERSION
+
+    destroy
+    false
+  end
+
   private
 
   def set_ffmpeg_version

--- a/app/models/content_length.rb
+++ b/app/models/content_length.rb
@@ -16,8 +16,9 @@ class ContentLength < ApplicationRecord
   validates :audio_file, presence: true, uniqueness: { scope: :codec_conversion }
   validates :codec_conversion, presence: true
   validates :length, presence: true
+  validates :ffmpeg_version, presence: true
 
-  before_save :set_ffmpeg_version
+  before_validation :set_ffmpeg_version
 
   def check_ffmpeg_version
     return true if ffmpeg_version == Rails.application.config.FFMPEG_VERSION

--- a/config/application.rb
+++ b/config/application.rb
@@ -35,5 +35,7 @@ module Accentor
     config.active_job.queue_adapter = :delayed_job
 
     config.transcode_cache_expiry = -> { 1.day.ago }
+    config.recalculate_content_length_if_longer_than = 299
+    config.recalculate_content_length_if_newer_than = -> { 1.month.ago }
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -35,7 +35,6 @@ module Accentor
     config.active_job.queue_adapter = :delayed_job
 
     config.transcode_cache_expiry = -> { 1.day.ago }
-    config.recalculate_content_length_if_longer_than = 299
-    config.recalculate_content_length_if_newer_than = -> { 1.month.ago }
+    config.recalculate_content_length_if = ->(af) { af.length > 299 || af.track.created_at.after?(1.month.ago) }
   end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -49,8 +49,7 @@ Rails.application.configure do
 
   # For tests we want these settings to remain the same, regardless of the configuration in application.rb
   config.transcode_cache_expiry = -> { 1.day.ago }
-  config.recalculate_content_length_if_longer_than = 299
-  config.recalculate_content_length_if_newer_than = -> { 1.month.ago }
+  config.recalculate_content_length_if = ->(af) { af.length > 299 || af.track.created_at.after?(1.month.ago) }
 
   config.token_hash_rounds = 1
   config.ffmpeg_log_location = Rails.root.join('tmp/log/ffmpeg.log').to_s

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -47,9 +47,10 @@ Rails.application.configure do
   config.active_job.queue_adapter = :delayed_job
   Delayed::Worker.delay_jobs = false
 
-  # For tests we want to be the transcode cache expiry setting to remain
-  # the same, regardless of the configuration in application.rb
+  # For tests we want these settings to remain the same, regardless of the configuration in application.rb
   config.transcode_cache_expiry = -> { 1.day.ago }
+  config.recalculate_content_length_if_longer_than = 299
+  config.recalculate_content_length_if_newer_than = -> { 1.month.ago }
 
   config.token_hash_rounds = 1
   config.ffmpeg_log_location = Rails.root.join('tmp/log/ffmpeg.log').to_s

--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -11,5 +11,6 @@ Delayed::Worker.queue_attributes = {
   transcodes: { priority: 5 },
   rescans: { priority: 10 },
   content_lengths: { priority: 20 },
+  content_lengths_backlog: { priority: 25 },
   transcode_cache_cleaner: { priority: 100 }
 }

--- a/config/initializers/ffmpeg.rb
+++ b/config/initializers/ffmpeg.rb
@@ -6,5 +6,5 @@ if Rails.env.test?
 else
   stdin, stdout, = Open3.popen2('ffmpeg -version')
   stdin.close
-  Rails.application.config.FFMPEG_VERSION = stdout.gets.match(/ffmpeg version (\d+\.\d+\.\d+)/)[1]
+  Rails.application.config.FFMPEG_VERSION = stdout.gets.match(/ffmpeg version (\d+\.\d+\.?\d*)/)[1]
 end

--- a/config/initializers/ffmpeg.rb
+++ b/config/initializers/ffmpeg.rb
@@ -1,0 +1,10 @@
+require 'open3'
+
+if Rails.env.test?
+  # We don't require test setups to have FFMPEG installed, so can jsut manually set a version
+  Rails.application.config.FFMPEG_VERSION = '0.0.1'
+else
+  stdin, stdout, = Open3.popen2('ffmpeg -version')
+  stdin.close
+  Rails.application.config.FFMPEG_VERSION = stdout.gets.match(/ffmpeg version (\d\.\d\.\d)/)[1]
+end

--- a/config/initializers/ffmpeg.rb
+++ b/config/initializers/ffmpeg.rb
@@ -1,8 +1,7 @@
 require 'open3'
 
 if Rails.env.test?
-  # We don't require test setups to have FFMPEG installed, so can jsut manually set a version
-  Rails.application.config.FFMPEG_VERSION = '0.0.1'
+  # We don't require test setups to have FFMPEG installed, so can just manually set a version
 else
   stdin, stdout, = Open3.popen2('ffmpeg -version')
   stdin.close

--- a/config/initializers/ffmpeg.rb
+++ b/config/initializers/ffmpeg.rb
@@ -6,5 +6,5 @@ if Rails.env.test?
 else
   stdin, stdout, = Open3.popen2('ffmpeg -version')
   stdin.close
-  Rails.application.config.FFMPEG_VERSION = stdout.gets.match(/ffmpeg version (\d\.\d\.\d)/)[1]
+  Rails.application.config.FFMPEG_VERSION = stdout.gets.match(/ffmpeg version (\d+\.\d+\.\d+)/)[1]
 end

--- a/config/initializers/ffmpeg.rb
+++ b/config/initializers/ffmpeg.rb
@@ -2,6 +2,7 @@ require 'open3'
 
 if Rails.env.test?
   # We don't require test setups to have FFMPEG installed, so can just manually set a version
+  Rails.application.config.FFMPEG_VERSION = '0.0.0'
 else
   stdin, stdout, = Open3.popen2('ffmpeg -version')
   stdin.close

--- a/config/initializers/ffmpeg.rb
+++ b/config/initializers/ffmpeg.rb
@@ -6,5 +6,6 @@ if Rails.env.test?
 else
   stdin, stdout, = Open3.popen2('ffmpeg -version')
   stdin.close
+  # ffmpeg versions can be either x.x.x or x.x
   Rails.application.config.FFMPEG_VERSION = stdout.gets.match(/ffmpeg version (\d+\.\d+\.?\d*)/)[1]
 end

--- a/db/migrate/20210221102324_add_ffmpeg_version_to_content_length.rb
+++ b/db/migrate/20210221102324_add_ffmpeg_version_to_content_length.rb
@@ -1,0 +1,7 @@
+class AddFfmpegVersionToContentLength < ActiveRecord::Migration[6.1]
+  def change
+    add_column :content_lengths, :ffmpeg_version, :string
+    ContentLength.update_all(ffmpeg_version: Rails.application.config.FFMPEG_VERSION)
+    change_column_null :content_lengths, :ffmpeg_version, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_12_115622) do
+ActiveRecord::Schema.define(version: 2021_02_21_102324) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -130,6 +130,7 @@ ActiveRecord::Schema.define(version: 2020_12_12_115622) do
     t.bigint "audio_file_id", null: false
     t.bigint "codec_conversion_id", null: false
     t.integer "length", null: false
+    t.string "ffmpeg_version", null: false
     t.index ["audio_file_id", "codec_conversion_id"], name: "index_content_lengths_on_audio_file_id_and_codec_conversion_id", unique: true
     t.index ["audio_file_id"], name: "index_content_lengths_on_audio_file_id"
     t.index ["codec_conversion_id"], name: "index_content_lengths_on_codec_conversion_id"

--- a/lib/tasks/check_ffmpeg_version.rake
+++ b/lib/tasks/check_ffmpeg_version.rake
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# use eslint for JS code styling
+namespace :ffmpeg do
+  task queue_check: :environment do
+    ContentLength.find_each do |cl|
+      cl.delay(queue: :content_lengths).check_ffmpeg_version
+    end
+  end
+end

--- a/lib/tasks/ffmpeg.rake
+++ b/lib/tasks/ffmpeg.rake
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
-# use eslint for JS code styling
 namespace :ffmpeg do
-  task queue_check: :environment do
+  task queue_version_checks: :environment do
     ContentLength.find_each do |cl|
       cl.delay(queue: :content_lengths).check_ffmpeg_version
     end

--- a/lib/tasks/ffmpeg.rake
+++ b/lib/tasks/ffmpeg.rake
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 namespace :ffmpeg do
   task queue_version_checks: :environment do
     ContentLength.find_each do |cl|

--- a/test/factories/content_lengths.rb
+++ b/test/factories/content_lengths.rb
@@ -3,6 +3,7 @@
 # Table name: content_lengths
 #
 #  id                  :bigint           not null, primary key
+#  ffmpeg_version      :string           not null
 #  length              :integer          not null
 #  audio_file_id       :bigint           not null
 #  codec_conversion_id :bigint           not null

--- a/test/models/content_length_test.rb
+++ b/test/models/content_length_test.rb
@@ -26,21 +26,60 @@ class ContentLengthTest < ActiveSupport::TestCase
   end
 
   test 'should remain if ffmpeg version matches' do
-    @content_length.check_ffmpeg_version
-    @content_length.reload
-    assert_not_nil @content_length.id
+    assert_difference('ContentLength.count', 0) do
+      @content_length.check_ffmpeg_version
+    end
   end
 
-  test 'should destroy if ffmpeg version does not match' do
+  test 'should not create new ContentLength if audio is longer than config and track is older than config' do
+    @track = create(:track, audio_file: @audio_file)
+
     # rubocop:disable Rails/SkipsModelValidations
-    # We want to avoid our own before_save callback to manually set a wrong version
+    # We want to avoid our own before_save callbacks to manually set a wrong version and audio_file length
+    @audio_file.update_column(:length, 1)
+    @audio_file.track.update_column(:created_at, 1.year.ago)
     @content_length.update_column(:ffmpeg_version, Faker::App.semantic_version)
     # rubocop:enable Rails/SkipsModelValidations
-    assert_not_equal Rails.application.config.FFMPEG_VERSION, @content_length.ffmpeg_version
-    @content_length.check_ffmpeg_version
 
-    assert_raises(ActiveRecord::RecordNotFound) do
-      @content_length.reload
+    assert_difference('ContentLength.count', -1) do
+      @content_length.check_ffmpeg_version
     end
+  end
+
+  test 'should create new ContentLength if audio is longer than config' do
+    io = StringIO.new File.read(Rails.root.join('test/files/base.flac'))
+    AudioFile.any_instance.stubs(:convert).returns(io)
+    @track = create(:track, audio_file: @audio_file)
+
+    # rubocop:disable Rails/SkipsModelValidations
+    # We want to avoid our own before_save callbacks to manually set a wrong version and audio_file length
+    @content_length.update_column(:ffmpeg_version, Faker::App.semantic_version)
+    @audio_file.update_column(:length, 1000)
+    @audio_file.track.update_column(:created_at, 1.year.ago)
+    # rubocop:enable Rails/SkipsModelValidations
+
+    assert_difference('ContentLength.count', 0) do
+      @content_length.check_ffmpeg_version
+    end
+  end
+
+  test 'should create new ContentLength if track is newer than config' do
+    io = StringIO.new File.read(Rails.root.join('test/files/base.flac'))
+    AudioFile.any_instance.stubs(:convert).returns(io)
+    @track = create(:track, audio_file: @audio_file)
+
+    # rubocop:disable Rails/SkipsModelValidations
+    # We want to avoid our own before_save callbacks to manually set a wrong version and audio_file length
+    @content_length.update_column(:ffmpeg_version, Faker::App.semantic_version)
+    @audio_file.update_column(:length, 1)
+    @audio_file.track.update_column(:created_at, 1.day.ago)
+    # rubocop:enable Rails/SkipsModelValidations
+
+    assert_difference('ContentLength.count', 0) do
+      @content_length.check_ffmpeg_version
+    end
+
+    @audio_file.reload
+    assert_equal 1, @audio_file.content_lengths.length
   end
 end

--- a/test/models/content_length_test.rb
+++ b/test/models/content_length_test.rb
@@ -3,6 +3,7 @@
 # Table name: content_lengths
 #
 #  id                  :bigint           not null, primary key
+#  ffmpeg_version      :string           not null
 #  length              :integer          not null
 #  audio_file_id       :bigint           not null
 #  codec_conversion_id :bigint           not null
@@ -11,4 +12,17 @@
 require 'test_helper'
 
 class ContentLengthTest < ActiveSupport::TestCase
+  def setup
+    # ContentLengths are automatically created when we create an AudioFile and CodecConversion. Manually creating one would result in an error due to uniqueness contraints.
+    io = StringIO.new File.read(Rails.root.join('test/files/base.flac'))
+    AudioFile.any_instance.stubs(:convert).returns(io)
+    @audio_file = create(:audio_file)
+    @codec_conversion = create(:codec_conversion)
+    @content_length = ContentLength.first
+  end
+
+  test 'should automatically provide ffmpeg version' do
+    assert_equal Rails.application.config.FFMPEG_VERSION, @content_length.ffmpeg_version
+  end
+
 end


### PR DESCRIPTION
<!--
Thanks for contributing to Accentor!
Make sure all GitHub actions (test & lint) will pass and fill out the template.

You can tag your PR with the relevant tags and request a review from someone of the team.
If any changes to your PR are necessary, we will ask for them through the review process.
 -->

# Description
Fix #175 

This PR adds an initializer to get the version of ffmpeg installed and a ffmpeg_version attribute to all `ContentLength`s to we can keep track of the version.

It also adds a task `ffmpeg:queue_version_checks`, to queue a check for all content lengths. This task should be added to deploy scripts or can be manually triggered.
(The initializers don't automatically have access to the models & delayed_job, so it seemed wrong to try and trigger the check there.).

If the ffmpeg_version has changed, the calculation for new `ContentLengths` is added at the end of the queue. There are currently two config options: when the related track was created and the length of the audio_file.
The default are 1 month ago and 5 minutes, but this can be debated. If we want all `ContentLength`s to be recalculated, we can set the length to 0.

# How Has This Been Tested?

- [x] I've added tests relevant to my changes
