### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,39 +6,29 @@ labels: bug
 assignees: ""
 ---
 
-<!--- Before you submit, make sure to check the following --->
+<!---
+  Before you submit, make sure to check that there are no similar
+  issues reported yet.
+  --->
 
-- [ ] There are no similar issues reported yet
+<!--- Give a clear and concise description of what the bug is. --->
 
-**Describe the bug**
-A clear and concise description of what the bug is.
+##### Reproduction steps
+<!---
+  Describe how a developer can reproduce your bug. If applicable, add
+  screenshots to help explain your problem. For example:
 
-**To Reproduce**
-Steps to reproduce the behavior:
+  1. Go to '...'
+  2. Click on '....'
+  3. Scroll down to '....'
+  4. See error
+  --->
 
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
+##### Expected behaviour
+<!--- Give a clear and concise description of what you expected to happen. --->
 
-**Expected behavior**
-A clear and concise description of what you expected to happen.
-
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
-
-**Desktop (please complete the following information):**
-
-- OS: [e.g. iOS]
-- Browser [e.g. chrome, safari]
-- Version [e.g. 22]
-
-**Smartphone (please complete the following information):**
-
-- Device: [e.g. iPhone6]
-- OS: [e.g. iOS8.1]
-- Browser [e.g. stock browser, safari]
-- Version [e.g. 22]
-
-**Additional context**
-Add any other context about the problem here.
+##### System information
+<!--- 
+  Mention what device you encountered this bug on. Include OS, browser
+  and their respective versions.
+  --->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,14 +6,14 @@ labels: enhancement
 assignees: ""
 ---
 
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
-
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
-
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
-
-**Additional context**
-Add any other context or screenshots about the feature request here.
+<!--- 
+  Before you submit, make sure to check that there are no similar
+  features requested yet.
+  --->
+  
+<!--- 
+  Give a clear and concise description of the usecase for your feature
+  request. What problem are you trying to solve, what do you think a
+  good solution might be, what alternatives to your solution do you
+  see?
+  --->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,22 +1,22 @@
-<!--
-Thanks for contributing to Accentor!
-Make sure all GitHub actions (test & lint) will pass and fill out the template.
+<!---
+  Thanks for contributing to Accentor!
+  Make sure all GitHub actions (test & lint) will pass and fill out
+  the template.
 
-You can tag your PR with the relevant tags and request a review from someone of the team.
-If any changes to your PR are necessary, we will ask for them through the review process.
- -->
+  If any changes to your PR are necessary, we will ask for them
+  throughout the review process.
+  --->
 
-## Description
+<!---
+  Please include a summary of the change and which issue is
+  fixed. Please also include relevant motivation and context.
+  --->
 
-Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
+Fixes #.
 
-Fix # (issue)
+- [ ] I've added tests relevant to my changes.
 
-# How Has This Been Tested?
-
-- [ ] I've added tests relevant to my changes
-
-Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-
-- [ ] Test A
-- [ ] Test B
+<!---
+  If you did any manual testing as well, please mention so
+  here. Provide instructions so we can reproduce those tests.
+  --->


### PR DESCRIPTION
Due to the introduction of task list support in GitHub, our issue
templates add a (useless, IMO) task list to every issue. I've changed
the template to remove the checkbox. I also edited the templates down
a little, to include less text by default.