### PR TITLE
Add GitHub action to automatically create a release when a tag is pushed

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,13 @@
+categories:
+  - title: '🚀 Features'
+    label: 'enhancement'
+  - title: '🐛 Bug Fixes'
+    label: 'bug'
+  - title: '🧰 Maintenance'
+    label: 'chore'
+  - title: '📖 Documentation'
+    label: 'documentation'
+exclude-labels:
+  - "dependencies"
+template: |
+  $CHANGES

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: Release
+
+on:
+  push:
+    tags:
+    - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Parse tag
+      id: parse_tag
+      run: "echo ${{ github.ref }} | sed 's#^refs/tags/#::set-output name=version::#'"
+    - name: Create release
+      id: create_release
+      uses: release-drafter/release-drafter@v5
+      with:
+        name: ${{ steps.parse_tag.outputs.version }}
+        tag: ${{ steps.parse_tag.outputs.version }}
+        version: ${{ steps.parse_tag.outputs.version }}
+        publish: true
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
You can see an example in the latest android release: https://github.com/accentor/android/releases/tag/v0.3.0