### PR TITLE
Always add composer from track's metadata

### DIFF
--- a/app/models/rescan_runner.rb
+++ b/app/models/rescan_runner.rb
@@ -128,7 +128,7 @@ class RescanRunner < ApplicationRecord
       role: :main,
       order: 1
     }]
-    if t_composer.present? && t_composer != t_artist
+    if t_composer.present?
       composer = Artist.find_by(name: t_composer) || Artist.new(name: t_composer, review_comment: 'New artist')
       track_artists << {
         artist: composer,


### PR DESCRIPTION
This PR changes the way a track's artists are set from the file's metadata during a rescan. Previously, we would not set a composer if the content of the composer field was equal to the content of the artist field. After this change, we always set the composer if the tag is present.

There are two reasons for this change:
1. The behaviour of the rescan becomes easier to comprehent. If a tag is present in the file, it will show up. The current behaviour can cause situations that are confusing to a user who is not familiar with the code. (For example, when some tracks on an album have the same composer and artists and others don't; or when some tracks have a misspelling of the composer/artist's name).
2. This sort of "fixes" should be handled while editing. The review comments, that are added by default to every new track, make it easy to have a backlog of items to go through. If a user don't want this duplication, they can remove it, if they want it, they can leave it.

There weren't any tests relevant to this behaviour. I haven't added/updated any tests, since we already had a test for adding a composer to the track.
