### PR TITLE
Allow images to be removed

### DIFF
--- a/app/controllers/albums_controller.rb
+++ b/app/controllers/albums_controller.rb
@@ -57,7 +57,9 @@ class AlbumsController < ApplicationController
   def transformed_attributes
     attributes = permitted_attributes(@album || Album)
 
-    if attributes[:image].present?
+    if attributes[:image].present? && attributes[:image][:data].nil?
+      attributes[:image] = nil
+    elsif attributes[:image].present?
       image_type = ImageType.find_by(extension: File.extname(attributes[:image][:filename])[1..].downcase) ||
                    ImageType.new(extension: File.extname(attributes[:image][:filename])[1..].downcase,
                                  mimetype: attributes[:image][:mimetype])

--- a/app/controllers/artists_controller.rb
+++ b/app/controllers/artists_controller.rb
@@ -60,7 +60,9 @@ class ArtistsController < ApplicationController
 
   def transformed_attributes
     attributes = permitted_attributes(@artist || Artist)
-    if attributes[:image].present?
+    if attributes[:image].present? && attributes[:image][:data].nil?
+      attributes[:image] = nil
+    elsif attributes[:image].present?
       image_type = ImageType.find_by(extension: File.extname(attributes[:image][:filename])[1..].downcase) ||
                    ImageType.new(extension: File.extname(attributes[:image][:filename])[1..].downcase,
                                  mimetype: attributes[:image][:mimetype])

--- a/test/controllers/albums_controller_test.rb
+++ b/test/controllers/albums_controller_test.rb
@@ -157,6 +157,25 @@ class AlbumsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test 'should destroy previous image when image is cleared' do
+    sign_in_as create(:moderator)
+    album = create :album, :with_release, :with_image
+
+    image = {
+      data: nil,
+      filename: nil,
+      mimetype: nil
+    }
+
+    assert_difference('Image.count', -1) do
+      patch album_url(album), params: { album: { image: image } }
+    end
+
+    assert_nil Album.find(album.id).image
+
+    assert_response :success
+  end
+
   test 'should not destroy album for user' do
     assert_difference('Album.count', 0) do
       delete album_url(@album)

--- a/test/controllers/artists_controller_test.rb
+++ b/test/controllers/artists_controller_test.rb
@@ -101,6 +101,25 @@ class ArtistsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test 'should destroy previous image when image is cleared' do
+    sign_in_as create(:moderator)
+    artist = create :artist, :with_image
+
+    image = {
+      data: nil,
+      filename: nil,
+      mimetype: nil
+    }
+
+    assert_difference('Image.count', -1) do
+      patch artist_url(artist), params: { artist: { image: image } }
+    end
+
+    assert_nil Artist.find(artist.id).image
+
+    assert_response :success
+  end
+
   test 'should not destroy artist for user' do
     assert_difference('Artist.count', 0) do
       delete artist_url(@artist)


### PR DESCRIPTION
I noticed that we currently aren't able to remove an image (only replace it), while working on Accentor/web#563
It shouldn't occur often, but we should probably provide this option. 

With the PR images can be reset if the params for an album/artist include `image: { data: nil }`. This way the image is only removed if we are very explicit about it, if `image: nil` is used nothing happens.

- [x] I've added tests relevant to my changes.


