### PR TITLE
Make gitignore for `/vendor/*` explicit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 # Ignore bundler config.
 /.bundle
 
+# Ignore files from vendors
+/vendor/*
+
 # Ignore all logfiles and tempfiles.
 /log/*
 /tmp/*


### PR DESCRIPTION
I removed this from my global gitignore for another project. Since we don't want these files to show up in git, it seems best to make this explicit