### PR TITLE
Set version inside application and add to headers

### DIFF
--- a/config/initializers/version.rb
+++ b/config/initializers/version.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Accentor
+  class Application
+    module Version
+      MAJOR = 0
+      MINOR = 13
+      PATCH = 0
+
+      STRING = [MAJOR, MINOR, PATCH].compact.join('.')
+    end
+    VERSION = Version::STRING
+
+    # Set version header for every request
+    config.action_dispatch.default_headers.merge!('X-API-Version' => VERSION)
+  end
+end


### PR DESCRIPTION
This PR does two things:
* Adds the application version in an initializer, so it can be used inside the application
* Adds an extra header to the default headers, with the version. (Which will be helpful when debugging in production or if we ever need to handle breaking changes in web/android)

A test didn't really seem relevant, but we can always test that the header is present in a random request