### PR TITLE
Make sure we allow two sibling dirs

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -10,16 +10,18 @@ class Location < ApplicationRecord
   has_many :audio_files, dependent: :destroy
 
   validates :path, presence: true, uniqueness: true
-  validate :cant_be_subdir_of_other_location
-  validate :cant_be_parent_of_other_location
+  validate :cant_be_parent_or_subdir_of_other_location
+
+  def expanded_path
+    Pathname.new(path).expand_path
+  end
 
   private
 
-  def cant_be_subdir_of_other_location
-    errors.add(:path, 'path-is-subdirectoy') unless Location.where('path LIKE ?', "#{path}%").empty?
-  end
-
-  def cant_be_parent_of_other_location
-    errors.add(:path, 'path-is-parent') unless Location.where("? LIKE path || '%'", path).empty?
+  def cant_be_parent_or_subdir_of_other_location
+    Location.find_each do |l|
+      errors.add(:path, 'path-is-subdirectoy') if expanded_path.fnmatch?(File.join(l.expanded_path, '**'))
+      errors.add(:path, 'path-is-parent') if l.expanded_path.fnmatch?(File.join(expanded_path, '**'))
+    end
   end
 end

--- a/test/models/location_test.rb
+++ b/test/models/location_test.rb
@@ -25,6 +25,11 @@ class LocationTest < ActiveSupport::TestCase
     assert_not_empty parent.errors[:path]
   end
 
+  test 'should be able to add similar siblings' do
+    sibling = build(:location, path: '/var/parent2')
+    assert sibling.valid?
+  end
+
   test 'location should not match parent/subdir if different case' do
     parent = build(:location, path: '/Var')
     assert parent.valid?


### PR DESCRIPTION
Re #254

I've changed the validation to actually use the pathname. Since this requires us to actually load the locations from the database, so I've merged the two validations into one, so we only have to do the iteration over the locations once.

This also has the benefit that relative paths will be expanded before the check happens - but I wouldn't immediatly know how to write a test for this.
