### PR TITLE
Add hidden attribute to TrackArtist

### DIFF
--- a/app/controllers/tracks_controller.rb
+++ b/app/controllers/tracks_controller.rb
@@ -140,7 +140,7 @@ class TracksController < ApplicationController
 
     if attributes[:track_artists].present?
       attributes[:track_artists] = attributes[:track_artists].map do |ta|
-        TrackArtist.new(artist_id: ta[:artist_id], name: ta[:name], role: ta[:role], order: ta[:order] || 0, hidden: ta[:hidden])
+        TrackArtist.new(artist_id: ta[:artist_id], name: ta[:name], role: ta[:role], order: ta[:order] || 0, hidden: ta[:hidden] || false)
       end
     end
 

--- a/app/controllers/tracks_controller.rb
+++ b/app/controllers/tracks_controller.rb
@@ -140,7 +140,7 @@ class TracksController < ApplicationController
 
     if attributes[:track_artists].present?
       attributes[:track_artists] = attributes[:track_artists].map do |ta|
-        TrackArtist.new(artist_id: ta[:artist_id], name: ta[:name], role: ta[:role], order: ta[:order] || 0)
+        TrackArtist.new(artist_id: ta[:artist_id], name: ta[:name], role: ta[:role], order: ta[:order] || 0, hidden: ta[:hidden])
       end
     end
 

--- a/app/models/track_artist.rb
+++ b/app/models/track_artist.rb
@@ -3,7 +3,7 @@
 # Table name: track_artists
 #
 #  id              :bigint           not null, primary key
-#  hidden          :boolean          default(FALSE)
+#  hidden          :boolean          default(FALSE), not null
 #  name            :string           not null
 #  normalized_name :string           not null
 #  order           :integer          not null

--- a/app/models/track_artist.rb
+++ b/app/models/track_artist.rb
@@ -3,6 +3,7 @@
 # Table name: track_artists
 #
 #  id              :bigint           not null, primary key
+#  hidden          :boolean          default(FALSE)
 #  name            :string           not null
 #  normalized_name :string           not null
 #  order           :integer          not null

--- a/app/policies/track_policy.rb
+++ b/app/policies/track_policy.rb
@@ -39,7 +39,7 @@ class TrackPolicy < ApplicationPolicy
 
   def permitted_attributes
     if user.moderator?
-      [:title, :number, :album_id, :review_comment, { genre_ids: [], track_artists: %i[artist_id name role order] }]
+      [:title, :number, :album_id, :review_comment, { genre_ids: [], track_artists: %i[artist_id name role order hidden] }]
     else
       [:review_comment]
     end

--- a/app/serializers/track_artist_serializer.rb
+++ b/app/serializers/track_artist_serializer.rb
@@ -3,7 +3,7 @@
 # Table name: track_artists
 #
 #  id              :bigint           not null, primary key
-#  hidden          :boolean          default(FALSE)
+#  hidden          :boolean          default(FALSE), not null
 #  name            :string           not null
 #  normalized_name :string           not null
 #  order           :integer          not null

--- a/app/serializers/track_artist_serializer.rb
+++ b/app/serializers/track_artist_serializer.rb
@@ -3,6 +3,7 @@
 # Table name: track_artists
 #
 #  id              :bigint           not null, primary key
+#  hidden          :boolean          default(FALSE)
 #  name            :string           not null
 #  normalized_name :string           not null
 #  order           :integer          not null
@@ -11,5 +12,5 @@
 #  track_id        :bigint           not null
 #
 class TrackArtistSerializer < ActiveModel::Serializer
-  attributes :artist_id, :name, :normalized_name, :role, :order
+  attributes :artist_id, :name, :normalized_name, :role, :order, :hidden
 end

--- a/db/migrate/20211127114919_add_hidden_to_track_artists.rb
+++ b/db/migrate/20211127114919_add_hidden_to_track_artists.rb
@@ -1,5 +1,5 @@
 class AddHiddenToTrackArtists < ActiveRecord::Migration[6.1]
   def change
-    add_column :track_artists, :hidden, :boolean, default: false
+    add_column :track_artists, :hidden, :boolean, default: false, null: false
   end
 end

--- a/db/migrate/20211127114919_add_hidden_to_track_artists.rb
+++ b/db/migrate/20211127114919_add_hidden_to_track_artists.rb
@@ -1,0 +1,5 @@
+class AddHiddenToTrackArtists < ActiveRecord::Migration[6.1]
+  def change
+    add_column :track_artists, :hidden, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -219,7 +219,7 @@ ActiveRecord::Schema.define(version: 2021_11_27_114919) do
     t.integer "role", null: false
     t.integer "order", null: false
     t.string "normalized_name", null: false
-    t.boolean "hidden", default: false
+    t.boolean "hidden", default: false, null: false
     t.index ["artist_id"], name: "index_track_artists_on_artist_id"
     t.index ["normalized_name"], name: "index_track_artists_on_normalized_name"
     t.index ["track_id", "artist_id", "name", "role"], name: "index_track_artists_on_track_id_and_artist_id_and_name_and_role", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_05_090539) do
+ActiveRecord::Schema.define(version: 2021_11_27_114919) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -219,6 +219,7 @@ ActiveRecord::Schema.define(version: 2021_09_05_090539) do
     t.integer "role", null: false
     t.integer "order", null: false
     t.string "normalized_name", null: false
+    t.boolean "hidden", default: false
     t.index ["artist_id"], name: "index_track_artists_on_artist_id"
     t.index ["normalized_name"], name: "index_track_artists_on_normalized_name"
     t.index ["track_id", "artist_id", "name", "role"], name: "index_track_artists_on_track_id_and_artist_id_and_name_and_role", unique: true

--- a/test/factories/track_artists.rb
+++ b/test/factories/track_artists.rb
@@ -3,7 +3,7 @@
 # Table name: track_artists
 #
 #  id              :bigint           not null, primary key
-#  hidden          :boolean          default(FALSE)
+#  hidden          :boolean          default(FALSE), not null
 #  name            :string           not null
 #  normalized_name :string           not null
 #  order           :integer          not null

--- a/test/factories/track_artists.rb
+++ b/test/factories/track_artists.rb
@@ -3,6 +3,7 @@
 # Table name: track_artists
 #
 #  id              :bigint           not null, primary key
+#  hidden          :boolean          default(FALSE)
 #  name            :string           not null
 #  normalized_name :string           not null
 #  order           :integer          not null

--- a/test/models/track_artist_test.rb
+++ b/test/models/track_artist_test.rb
@@ -3,7 +3,7 @@
 # Table name: track_artists
 #
 #  id              :bigint           not null, primary key
-#  hidden          :boolean          default(FALSE)
+#  hidden          :boolean          default(FALSE), not null
 #  name            :string           not null
 #  normalized_name :string           not null
 #  order           :integer          not null

--- a/test/models/track_artist_test.rb
+++ b/test/models/track_artist_test.rb
@@ -3,6 +3,7 @@
 # Table name: track_artists
 #
 #  id              :bigint           not null, primary key
+#  hidden          :boolean          default(FALSE)
 #  name            :string           not null
 #  normalized_name :string           not null
 #  order           :integer          not null


### PR DESCRIPTION
Allows mod+ to "hide" a TrackArtist. This way, detailed credits can be added to a song, while the main overviews will stay minimal (if that is what is wanted for a track).

No additional tests added - since I couldn't think of a relevant test here.