### PR TITLE
Fix migration for rescan runner per location

### DIFF
--- a/db/migrate/20210905090539_add_location_to_rescan_runner.rb
+++ b/db/migrate/20210905090539_add_location_to_rescan_runner.rb
@@ -1,6 +1,6 @@
 class AddLocationToRescanRunner < ActiveRecord::Migration[6.1]
   def change
-    RescanRunner.destroy_all
+    ActiveRecord::Base.connection.execute("TRUNCATE rescan_runners")
 
     add_reference :rescan_runners, :location, null: false, foreign_key: true
 


### PR DESCRIPTION
The migration didn't work, because `destroy_all` went looking for the relevant location (since there is a `belongs_to` in the model).