### PR TITLE
Unauthorized play tokens

### DIFF
--- a/app/controllers/tracks_controller.rb
+++ b/app/controllers/tracks_controller.rb
@@ -1,6 +1,7 @@
 class TracksController < ApplicationController
   include ActionController::Live
 
+  before_action :authenticate_from_play_token, only: %i[audio]
   before_action :set_track, only: %i[show update destroy audio merge]
 
   has_scope :by_filter, as: 'filter'
@@ -85,6 +86,13 @@ class TracksController < ApplicationController
   end
 
   private
+
+  def authenticate_from_play_token
+    return if current_user.present?
+
+    token = AuthToken.find_by(play_token: params[:play_token])
+    self.current_user = token&.user
+  end
 
   def audio_with_file(path, mimetype)
     file = File.open(path, 'rb')

--- a/app/models/auth_token.rb
+++ b/app/models/auth_token.rb
@@ -4,6 +4,7 @@
 #
 #  id            :bigint           not null, primary key
 #  hashed_secret :string           not null
+#  play_token    :string           not null
 #  user_agent    :string           not null
 #  device_id     :string           not null
 #  user_id       :bigint           not null
@@ -14,9 +15,11 @@ class AuthToken < ApplicationRecord
 
   validates :device_id, presence: true, uniqueness: true
   validates :hashed_secret, presence: true
+  validates :play_token, presence: true
   validates :user_agent, presence: true
   before_validation :generate_device_id, unless: :device_id?
   before_validation :generate_secret, unless: :hashed_secret?
+  before_validation :generate_play_token, unless: :play_token?
 
   attr_accessor :secret
 
@@ -41,5 +44,12 @@ class AuthToken < ApplicationRecord
   def generate_secret
     self.secret = SecureRandom.urlsafe_base64(48)
     self.hashed_secret = BCrypt::Password.create(secret, cost: Rails.configuration.token_hash_rounds)
+  end
+
+  def generate_play_token
+    loop do
+      self.play_token = SecureRandom.urlsafe_base64(48)
+      break unless AuthToken.exists?(play_token: play_token)
+    end
   end
 end

--- a/app/serializers/auth_token_serializer.rb
+++ b/app/serializers/auth_token_serializer.rb
@@ -10,5 +10,5 @@
 #  user_id       :bigint           not null
 #
 class AuthTokenSerializer < ActiveModel::Serializer
-  attributes :id, :device_id, :user_id, :user_agent
+  attributes :id, :device_id, :user_id, :user_agent, :play_token
 end

--- a/app/serializers/auth_token_serializer.rb
+++ b/app/serializers/auth_token_serializer.rb
@@ -4,6 +4,7 @@
 #
 #  id            :bigint           not null, primary key
 #  hashed_secret :string           not null
+#  play_token    :string           not null
 #  user_agent    :string           not null
 #  device_id     :string           not null
 #  user_id       :bigint           not null

--- a/db/migrate/20211228193422_add_play_token_to_auth_token.rb
+++ b/db/migrate/20211228193422_add_play_token_to_auth_token.rb
@@ -1,0 +1,19 @@
+class AddPlayTokenToAuthToken < ActiveRecord::Migration[6.1]
+
+  def up
+    change_table :auth_tokens do |t|
+      t.string :play_token, null: true
+      t.index :play_token
+    end
+    AuthToken.find_each do |token|
+      token.validate # will trigger generate_play_token
+      token.save
+    end
+    change_column :auth_tokens, :play_token, :string, null: false
+  end
+
+  def down
+    remove_index :auth_tokens, :play_token
+    remove_column :auth_tokens, :play_token
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_27_114919) do
+ActiveRecord::Schema.define(version: 2021_12_28_193422) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -108,7 +108,9 @@ ActiveRecord::Schema.define(version: 2021_11_27_114919) do
     t.string "device_id", null: false
     t.string "hashed_secret", null: false
     t.string "user_agent", null: false
+    t.string "play_token", null: false
     t.index ["device_id"], name: "index_auth_tokens_on_device_id", unique: true
+    t.index ["play_token"], name: "index_auth_tokens_on_play_token"
     t.index ["user_id"], name: "index_auth_tokens_on_user_id"
   end
 

--- a/test/controllers/tracks_controller_test.rb
+++ b/test/controllers/tracks_controller_test.rb
@@ -206,6 +206,31 @@ class TracksControllerTest < ActionDispatch::IntegrationTest
   end
 end
 
+class TracksControllerPlayTokenTest < ActionDispatch::IntegrationTest
+  test 'should not serve audio to user without tokens' do
+    location = Location.create(path: Rails.root.join('test/files'))
+    audio_file = create(:audio_file, location: location, filename: '/base.flac')
+    track = create(:track, audio_file: audio_file)
+
+    get audio_track_url(track)
+
+    assert_response :unauthorized
+  end
+
+  test 'should serve audio to user with play token' do
+    token = create(:auth_token)
+    user = token.user
+
+    location = Location.create(path: Rails.root.join('test/files'))
+    audio_file = create(:audio_file, location: location, filename: '/base.flac')
+    track = create(:track, audio_file: audio_file)
+
+    get audio_track_url(track, play_token: token.play_token)
+
+    assert_response :success
+  end
+end
+
 class TracksControllerAudioTest < ActionDispatch::IntegrationTest
   setup do
     sign_in_as(create(:user))

--- a/test/factories/auth_tokens.rb
+++ b/test/factories/auth_tokens.rb
@@ -4,6 +4,7 @@
 #
 #  id            :bigint           not null, primary key
 #  hashed_secret :string           not null
+#  play_token    :string           not null
 #  user_agent    :string           not null
 #  device_id     :string           not null
 #  user_id       :bigint           not null

--- a/test/models/auth_token_test.rb
+++ b/test/models/auth_token_test.rb
@@ -4,6 +4,7 @@
 #
 #  id            :bigint           not null, primary key
 #  hashed_secret :string           not null
+#  play_token    :string           not null
 #  user_agent    :string           not null
 #  device_id     :string           not null
 #  user_id       :bigint           not null


### PR DESCRIPTION
<!---
  Thanks for contributing to Accentor!
  Make sure all GitHub actions (test & lint) will pass and fill out
  the template.

  If any changes to your PR are necessary, we will ask for them
  throughout the review process.
  --->

This PR adds a `play_token` to `AuthToken`s which can only be used to fetch a track's audio with. This can be used to implement streaming from untrusted devices.

Further security improvements are probably possible. Suggestions for more secure ways to handle this use case are very welcome.

<!---
  Please include a summary of the change and which issue is
  fixed. Please also include relevant motivation and context.
  --->

Fixes #.

- [x] I've added tests relevant to my changes.

<!---
  If you did any manual testing as well, please mention so
  here. Provide instructions so we can reproduce those tests.
  --->
