### PR TITLE
Calc play count per user in SQL view

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,9 @@ gem 'bootsnap', '~> 1.11.1', require: false
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 gem 'rack-cors', '~> 1.1'
 
+# Use Scenic to easily create (materialized) views in postgresql
+gem 'scenic', '~> 1.6'
+
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -218,6 +218,9 @@ GEM
     ruby-progressbar (1.11.0)
     ruby-vips (2.1.4)
       ffi (~> 1.12)
+    scenic (1.6.0)
+      activerecord (>= 4.0.0)
+      railties (>= 4.0.0)
     simplecov (0.21.2)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -261,6 +264,7 @@ DEPENDENCIES
   rails (~> 7.0)
   rubocop-minitest (~> 0.18.0)
   rubocop-rails (~> 2.14)
+  scenic (~> 1.6)
   simplecov (~> 0.21)
   tzinfo-data
   wahwah (~> 1.3.0)

--- a/app/controllers/tracks_controller.rb
+++ b/app/controllers/tracks_controller.rb
@@ -1,4 +1,6 @@
 class TracksController < ApplicationController
+  serialization_scope :current_user
+
   include ActionController::Live
 
   before_action :set_track, only: %i[show update destroy audio merge]
@@ -11,7 +13,7 @@ class TracksController < ApplicationController
   def index
     authorize Track
     @tracks = apply_scopes(policy_scope(Track))
-              .includes(:track_artists, :genres, audio_file: %i[location codec])
+              .includes(:track_artists, :genres, :play_counts, audio_file: %i[location codec])
               .paginate(page: params[:page], per_page: params[:per_page])
     add_pagination_headers(@tracks)
 

--- a/app/models/play_count.rb
+++ b/app/models/play_count.rb
@@ -1,0 +1,16 @@
+# == Schema Information
+#
+# Table name: play_counts
+#
+#  play_count :bigint
+#  track_id   :bigint
+#  user_id    :bigint
+#
+class PlayCount < ApplicationRecord
+  belongs_to :track
+  belongs_to :user
+
+  def readonly?
+    true
+  end
+end

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -36,6 +36,11 @@ class Track < ApplicationRecord
   scope :by_album, ->(album) { where(album:) }
   scope :by_genre, ->(genre) { joins(:genres).where(genres: { id: genre }) }
 
+  def play_count(user)
+    # To avoid N+1 queries, we check whether we have already loaded the associated play_counts
+    play_counts.loaded? ? play_counts.find { |c| c.user_id == user.id }.play_count : play_counts.find_by(user:).play_count
+  end
+
   def merge(other)
     af = other.audio_file
     # rubocop:disable Rails/SkipsModelValidations

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -22,6 +22,7 @@ class Track < ApplicationRecord
   has_many :track_artists, dependent: :destroy
   has_many :artists, through: :track_artists, source: :artist
   has_many :plays, dependent: :destroy
+  has_many :play_counts, dependent: nil
 
   validates :title, presence: true
   validates :number, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,6 +15,7 @@ class User < ApplicationRecord
 
   has_many :auth_tokens, dependent: :destroy
   has_many :plays, dependent: :destroy
+  has_many :play_counts, dependent: nil
 
   validates :name, presence: true, uniqueness: true
   validates :password_digest, presence: true

--- a/app/serializers/track_serializer.rb
+++ b/app/serializers/track_serializer.rb
@@ -13,9 +13,13 @@
 #  audio_file_id    :bigint
 #
 class TrackSerializer < ActiveModel::Serializer
-  attributes :id, :title, :normalized_title, :number, :album_id, :review_comment, :created_at, :updated_at, :genre_ids, :codec_id, :length, :bitrate, :location_id
+  attributes :id, :title, :normalized_title, :number, :album_id, :review_comment, :created_at, :updated_at, :genre_ids, :play_count, :codec_id, :length, :bitrate, :location_id
 
   has_many :track_artists
+
+  def play_count
+    object.play_count(scope)
+  end
 
   def codec_id
     object.audio_file&.codec_id

--- a/db/migrate/20220326090719_create_play_counts.rb
+++ b/db/migrate/20220326090719_create_play_counts.rb
@@ -1,0 +1,5 @@
+class CreatePlayCounts < ActiveRecord::Migration[7.0]
+  def change
+    create_view :play_counts
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_02_19_105635) do
+ActiveRecord::Schema[7.0].define(version: 2022_03_26_090719) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -285,4 +285,14 @@ ActiveRecord::Schema[7.0].define(version: 2022_02_19_105635) do
   add_foreign_key "tracks", "audio_files"
   add_foreign_key "transcoded_items", "audio_files"
   add_foreign_key "transcoded_items", "codec_conversions"
+
+  create_view "play_counts", sql_definition: <<-SQL
+      SELECT users.id AS user_id,
+      tracks.id AS track_id,
+      count(plays.id) AS play_count
+     FROM ((tracks
+       LEFT JOIN users ON ((true = true)))
+       LEFT JOIN plays ON (((tracks.id = plays.track_id) AND (users.id = plays.user_id))))
+    GROUP BY users.id, tracks.id;
+  SQL
 end

--- a/db/views/play_counts_v01.sql
+++ b/db/views/play_counts_v01.sql
@@ -1,0 +1,13 @@
+-- This view generates a count per user/track
+SELECT
+  users.id as user_id,
+  tracks.id as track_id,
+  COUNT(plays.id) as play_count
+FROM
+  tracks
+  LEFT OUTER JOIN users ON true = true
+  LEFT OUTER JOIN plays ON tracks.id = plays.track_id
+  AND users.id = plays.user_id
+GROUP BY
+  users.id,
+  tracks.id

--- a/test/models/play_count_test.rb
+++ b/test/models/play_count_test.rb
@@ -1,0 +1,46 @@
+# == Schema Information
+#
+# Table name: play_counts
+#
+#  play_count :bigint
+#  track_id   :bigint
+#  user_id    :bigint
+#
+require 'test_helper'
+
+class PlayCountTest < ActiveSupport::TestCase
+  setup do
+    @user = create(:user)
+    @track = create(:track)
+    create(:play, user: @user, track: @track)
+  end
+
+  test 'should be readonly' do
+    assert_raise ActiveRecord::ReadOnlyRecord do
+      PlayCount.first.update(count: 20)
+    end
+  end
+
+  test 'should calc play count per user and track' do
+    assert_equal 1, PlayCount.where(user: @user, track: @track).length
+    assert_equal 1, PlayCount.find_by(user: @user, track: @track).play_count
+  end
+
+  test 'should ignore plays from other users' do
+    create(:play, track: @track)
+    assert_equal 1, PlayCount.where(user: @user, track: @track).length
+    assert_equal 1, PlayCount.find_by(user: @user, track: @track).play_count
+  end
+
+  test 'should ignore plays of other tracks' do
+    create(:play, user: @user)
+    assert_equal 1, PlayCount.where(user: @user, track: @track).length
+    assert_equal 1, PlayCount.find_by(user: @user, track: @track).play_count
+  end
+
+  test 'should create a count per track/user, even if there are no plays' do
+    user = create(:user)
+    assert_equal 1, PlayCount.where(user:, track: @track).length
+    assert_equal 0, PlayCount.find_by(user:, track: @track).play_count
+  end
+end

--- a/test/models/play_count_test.rb
+++ b/test/models/play_count_test.rb
@@ -17,7 +17,7 @@ class PlayCountTest < ActiveSupport::TestCase
 
   test 'should be readonly' do
     assert_raise ActiveRecord::ReadOnlyRecord do
-      PlayCount.first.update(count: 20)
+      PlayCount.first.update(play_count: 20)
     end
   end
 

--- a/test/models/track_test.rb
+++ b/test/models/track_test.rb
@@ -132,4 +132,19 @@ class TrackTest < ActiveSupport::TestCase
     assert_equal 1, ta1.order
     assert_equal 2, ta2.order
   end
+
+  test 'reports play_count for user' do
+    track = create(:track)
+    user = create(:user)
+    create(:play, track:, user:)
+
+    assert_equal 1, track.play_count(user)
+  end
+
+  test 'reports play_count for user if no plays exist' do
+    track = create(:track)
+    user = create(:user)
+
+    assert_equal 0, track.play_count(user)
+  end
 end


### PR DESCRIPTION
In the web app, we currently fetch all play data quite a lot:
* With each global reload
* Every time the user goes to an album page

While we do very little with it. On most pages we only display the play count for each track. The stats pages are the only ones where we actually need the plays themselves, to do more finegrained calculations.

In the initial implementation of the plays, we didn't include the play count with the tracks, since we didn't find a good way to include this data only for the current user.

In this PR:
* [x] I added [scenic](https://github.com/scenic-views/scenic) to easily work with PostgreSQL's (materialized) views - it provides an easy way to manage the views in migrations and manage different versions of a view and then consume those views as if they were regular models/tables
* [x] Created a view to calculate a play_count per user/track
* [x] Used that view to include the play_count for the current user with the tracks

## Open questions
### Load/responses times
I currently created a view, which runs each time it is accessed. We'll have to see if this doesn't cause too much load or longer response times for the tracks.
On my dev machine (with ±150 tracks and ±40000 plays) I could load the whole view in ±30ms. There also was no notable difference in the response times of the `TracksController` (Note that these views will only calculate the relevant data. So `User.first.play_counts` should generally be faster than `PlayCount.all`. In the case of the TracksController, this should mean that only the play counts for the 500 tracks that will be returned are calculated on each request.)
If this turns out to cause too much load/delay, we could switch to a materialized view, but then we also have to figure out how and when to refresh the view.

### Including play_count in TrackSerializer
When I started working on this, I did not think that it would be this complex to include the play_counts with in the TracksSerializer.
I assumed that
```ruby
Track.includes(:play_counts).where(play_counts: { user: current_user }).first.play_counts.length
# => 1
```
but it seemes that where clause is left out when we access the play_counts again, so we actually get the number of users.

That means we currently have to make the `TrackSerializer` aware of the current_user:
https://github.com/accentor/api/blob/7627202bac34a8d8f284bf80e2f96466a27a8d50/app/controllers/tracks_controller.rb#L2
And that we need a method that can efficiently load the play_count for a user, regardless of whether we have eager loaded the play_counts or not
https://github.com/accentor/api/blob/7627202bac34a8d8f284bf80e2f96466a27a8d50/app/models/track.rb#L39-L42

Maybe we shouldn't be returning these counts together with the tracks at all, but just through a separate endpoint? But then we start losing some of the advantages of this PR (namely, less API requests)