### PR TITLE
Nilify empty strings

### DIFF
--- a/app/models/album.rb
+++ b/app/models/album.rb
@@ -31,6 +31,7 @@ class Album < ApplicationRecord
   validate :album_artist_separators
 
   normalized_col_generator :title
+  normalize_blank_values :edition_description, :review_comment
 
   scope :by_filter, ->(filter) { where('"albums"."normalized_title" LIKE ?', "%#{Album.normalize(filter)}%") }
   scope :by_artist, ->(artist) { joins(:artists).where(artists: { id: artist }) }

--- a/app/models/album.rb
+++ b/app/models/album.rb
@@ -31,7 +31,7 @@ class Album < ApplicationRecord
   validate :album_artist_separators
 
   normalized_col_generator :title
-  normalize_blank_values :edition_description, :review_comment
+  nilify_blank_values :edition_description, :review_comment
 
   scope :by_filter, ->(filter) { where('"albums"."normalized_title" LIKE ?', "%#{Album.normalize(filter)}%") }
   scope :by_artist, ->(artist) { joins(:artists).where(artists: { id: artist }) }

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -16,7 +16,7 @@ class ApplicationRecord < ActiveRecord::Base
       set_callback :validation, :before, method_name, if: col_changed
 
       define_method method_name do
-        self[col].present? || self[col] = nil
+        self[col] = nil if self[col].blank?
       end
     end
   end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -7,4 +7,17 @@ class ApplicationRecord < ActiveRecord::Base
   def self.normalize(str)
     str.unicode_normalize(:nfkd).gsub(/[\u0300-\u036f]/, '').downcase
   end
+
+  def self.normalize_blank_values(*cols)
+    cols.each do |col|
+      col_changed = :"#{col}_changed?"
+      method_name = :"normalize_blank_#{col}_value"
+
+      set_callback :validation, :before, method_name, if: col_changed
+
+      define_method method_name do
+        self[col].present? || self[col] = nil
+      end
+    end
+  end
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -8,10 +8,10 @@ class ApplicationRecord < ActiveRecord::Base
     str.unicode_normalize(:nfkd).gsub(/[\u0300-\u036f]/, '').downcase
   end
 
-  def self.normalize_blank_values(*cols)
+  def self.nilify_blank_values(*cols)
     cols.each do |col|
       col_changed = :"#{col}_changed?"
-      method_name = :"normalize_blank_#{col}_value"
+      method_name = :"nilify_blank_#{col}_value"
 
       set_callback :validation, :before, method_name, if: col_changed
 

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -24,6 +24,7 @@ class Artist < ApplicationRecord
   validates :name, presence: true
 
   normalized_col_generator :name
+  normalize_blank_values :review_comment
 
   scope :by_filter, ->(filter) { where('normalized_name LIKE ?', "%#{Artist.normalize(filter)}%") }
 

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -24,7 +24,7 @@ class Artist < ApplicationRecord
   validates :name, presence: true
 
   normalized_col_generator :name
-  normalize_blank_values :review_comment
+  nilify_blank_values :review_comment
 
   scope :by_filter, ->(filter) { where('normalized_name LIKE ?', "%#{Artist.normalize(filter)}%") }
 

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -29,7 +29,7 @@ class Track < ApplicationRecord
   normalized_col_generator :title
 
   before_save :normalize_artist_order
-  normalize_blank_values :review_comment
+  nilify_blank_values :review_comment
 
   scope :by_filter, ->(filter) { where('"tracks"."normalized_title" LIKE ?', "%#{Track.normalize(filter)}%") }
   scope :by_artist, ->(artist) { joins(:artists).where(artists: { id: artist }) }

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -29,6 +29,7 @@ class Track < ApplicationRecord
   normalized_col_generator :title
 
   before_save :normalize_artist_order
+  normalize_blank_values :review_comment
 
   scope :by_filter, ->(filter) { where('"tracks"."normalized_title" LIKE ?', "%#{Track.normalize(filter)}%") }
   scope :by_artist, ->(artist) { joins(:artists).where(artists: { id: artist }) }

--- a/test/models/album_test.rb
+++ b/test/models/album_test.rb
@@ -72,4 +72,16 @@ class AlbumTest < ActiveSupport::TestCase
     assert_equal 1, aa1.order
     assert_equal 2, aa2.order
   end
+
+  test 'should normalize blank edition descriptions' do
+    album = build(:album, edition_description: '')
+    album.save
+    assert_nil album.edition_description
+  end
+
+  test 'should normalize blank review_comment' do
+    album = build(:album, review_comment: '')
+    album.save
+    assert_nil album.review_comment
+  end
 end

--- a/test/models/album_test.rb
+++ b/test/models/album_test.rb
@@ -73,13 +73,13 @@ class AlbumTest < ActiveSupport::TestCase
     assert_equal 2, aa2.order
   end
 
-  test 'should normalize blank edition descriptions' do
+  test 'should nilify blank edition descriptions' do
     album = build(:album, edition_description: '')
     album.save
     assert_nil album.edition_description
   end
 
-  test 'should normalize blank review_comment' do
+  test 'should nilify blank review_comment' do
     album = build(:album, review_comment: '')
     album.save
     assert_nil album.review_comment

--- a/test/models/artist_test.rb
+++ b/test/models/artist_test.rb
@@ -99,7 +99,7 @@ class ArtistTest < ActiveSupport::TestCase
     assert_not_empty artist2.errors[:album_artists]
   end
 
-  test 'should normalize blank review_comment' do
+  test 'should nilify blank review_comment' do
     track = build(:track, review_comment: '')
     track.save
     assert_nil track.review_comment

--- a/test/models/artist_test.rb
+++ b/test/models/artist_test.rb
@@ -98,4 +98,10 @@ class ArtistTest < ActiveSupport::TestCase
     end
     assert_not_empty artist2.errors[:album_artists]
   end
+
+  test 'should normalize blank review_comment' do
+    track = build(:track, review_comment: '')
+    track.save
+    assert_nil track.review_comment
+  end
 end

--- a/test/models/track_test.rb
+++ b/test/models/track_test.rb
@@ -132,4 +132,10 @@ class TrackTest < ActiveSupport::TestCase
     assert_equal 1, ta1.order
     assert_equal 2, ta2.order
   end
+
+  test 'should normalize blank review_comment' do
+    track = build(:track, review_comment: '')
+    track.save
+    assert_nil track.review_comment
+  end
 end

--- a/test/models/track_test.rb
+++ b/test/models/track_test.rb
@@ -133,7 +133,7 @@ class TrackTest < ActiveSupport::TestCase
     assert_equal 2, ta2.order
   end
 
-  test 'should normalize blank review_comment' do
+  test 'should nilify blank review_comment' do
     track = build(:track, review_comment: '')
     track.save
     assert_nil track.review_comment


### PR DESCRIPTION
This PR adds a method to define which values should be nullified if they are blank.

We want to have control over which columns should be normalized, since some columns (`AlbumArtist.separator`) can explicitly be an empty string but not nil.
I've currently added the Album's edition_description and all instances of the review_comment.

Fixes #316 
- [x] I've added tests relevant to my changes.

## Questions
This PR currently doesn't include way to fix this for all current places where the empty string is present. Should we leave this up to the user to fix (in the interface or console), or add a migration to go over all albums, artists and tracks.

I've currently included this method in `ApplicationRecord`, but could also see this being a concern that should be explicitly included in each model
