### PR TITLE
Allow database_host to be specified through ENV var

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -20,6 +20,7 @@ default: &default
   # For details on connection pooling, see Rails configuration guide
   # http://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  host: <%= ENV['DATABASE_HOST'] || 'localhost' %>
 
 development:
   <<: *default


### PR DESCRIPTION
In my local development setup I've been switching to a postgres instance per project, which runs in `tmp/postgres`.

To easily use this database, I'd like to set the database_host through an ENV variable. (I could also do this with a database_url, but this requires the variable to be URI encoded, where the host can be a regular path. It's just a bit easier to set `/path/to/accentor/api/tmp/postgres` rather than `postgres://%2fpath%2fto%2faccentor%2fapi%2ftmp%2fpostgres/accentor_development`)

Since I added the fallback to localhost, this should not cause any difference to other users. [Due to the way Rails' connection preference works](https://guides.rubyonrails.org/configuring.html#connection-preference), this also should not cause a difference for people who currently use the DATABASE_URL ENV var.