### PR TITLE
Only specify database host for development and test

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -20,13 +20,13 @@ default: &default
   # For details on connection pooling, see Rails configuration guide
   # http://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  host: <%= ENV['DATABASE_HOST'] || 'localhost' %>
 
 development:
   <<: *default
   username: accentor
   password: accentor
   database: accentor_development
+  host: <%= ENV['DATABASE_HOST'] || 'localhost' %>
   url: <%= ENV['DATABASE_URL'] %>
 
   # The specified database role being used to connect to postgres.
@@ -64,6 +64,7 @@ test:
   username: accentor
   password: accentor
   database: accentor_test
+  host: <%= ENV['DATABASE_HOST'] || 'localhost' %>
   url: <%= ENV['DATABASE_URL'] ? "#{ENV['DATABASE_URL']}_test" : nil %>
 
 # As with config/secrets.yml, you never want to store sensitive information,


### PR DESCRIPTION
This PR fixes a bug introduced in #319 

In production environments setting a `DATABASE_URL` variable with a unix socket, an error could occur where the database didn't allow connections:
```
PG::ConnectionBad: fe_sendauth: no password supplied
Caused by:
ActiveRecord::ConnectionNotEstablished: fe_sendauth: no password supplied
```

This seems to be caused by the way rails merges the URL variable with the config (instead of overwritten the whole config).

Since we only need a `DATABASE_HOST` variable in the development and test env - and it's generally recommended to set `DATABASE_URL` in production - I've simply moved the added config to those two environments.