### PR TITLE
Only process date tag if it is present

### DIFF
--- a/app/models/rescan_runner.rb
+++ b/app/models/rescan_runner.rb
@@ -197,7 +197,7 @@ class RescanRunner < ApplicationRecord
   end
 
   def convert_year(tag)
-    return Date.new(0) unless tag # WahWah returns nil if the file doesn't have a date tag
+    return Date.new(0) unless tag.present? # WahWah returns nil if the file doesn't have a date tag
 
     date = tag.split('-').map(&:to_i)
     Date.new(date[0], date[1] || 1, date[2] || 1)

--- a/app/models/rescan_runner.rb
+++ b/app/models/rescan_runner.rb
@@ -197,7 +197,7 @@ class RescanRunner < ApplicationRecord
   end
 
   def convert_year(tag)
-    return Date.new(0) unless tag.present? # WahWah returns nil if the file doesn't have a date tag
+    return Date.new(0) if tag.blank? # WahWah returns nil if the file doesn't have a date tag
 
     date = tag.split('-').map(&:to_i)
     Date.new(date[0], date[1] || 1, date[2] || 1)


### PR DESCRIPTION
If an audio file contained a date tag with an empty string, we would run into the following error
```
An error occurred while processing /path/to/file.flac: invalid year (not numeric)
/app/models/rescan_runner.rb:203:in `initialize'
/app/models/rescan_runner.rb:203:in `new'
/app/models/rescan_runner.rb:203:in `convert_year'
/app/models/rescan_runner.rb:95:in `process_file'
/app/models/rescan_runner.rb:72:in `block (2 levels) in process_all_files
```

We now check `if tag.blank?` so both `nil` and empty strings are captured

No tests added, since my tag editor doesn't allow me to add dates with empty strings 🤷 