### PR TITLE
Enforce album release date

### DIFF
--- a/app/models/album.rb
+++ b/app/models/album.rb
@@ -6,7 +6,7 @@
 #  edition             :date
 #  edition_description :string
 #  normalized_title    :string           not null
-#  release             :date
+#  release             :date             default(Thu, 01 Jan 0000), not null
 #  review_comment      :string
 #  title               :string           not null
 #  created_at          :datetime         not null

--- a/app/models/rescan_runner.rb
+++ b/app/models/rescan_runner.rb
@@ -197,7 +197,7 @@ class RescanRunner < ApplicationRecord
   end
 
   def convert_year(tag)
-    return Date.new(0) if tag.blank? # WahWah returns nil if the file doesn't have a date tag
+    return if tag.blank? # WahWah returns nil if the file doesn't have a date tag
 
     date = tag.split('-').map(&:to_i)
     Date.new(date[0], date[1] || 1, date[2] || 1)

--- a/app/serializers/album_serializer.rb
+++ b/app/serializers/album_serializer.rb
@@ -6,7 +6,7 @@
 #  edition             :date
 #  edition_description :string
 #  normalized_title    :string           not null
-#  release             :date
+#  release             :date             default(Thu, 01 Jan 0000), not null
 #  review_comment      :string
 #  title               :string           not null
 #  created_at          :datetime         not null

--- a/db/migrate/20220430121719_change_null_album_release.rb
+++ b/db/migrate/20220430121719_change_null_album_release.rb
@@ -1,0 +1,11 @@
+class ChangeNullAlbumRelease < ActiveRecord::Migration[7.0]
+  def change
+    Album.where(release: nil).find_each do |a|
+      # Skip validations, so this can't get stuck on other possible issues
+      a.update_column(:release, Date.new(0))
+    end
+
+    change_column_null :albums, :release, false
+    change_column_default :albums, :release, from: nil, to: Date.new(0)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_02_19_105635) do
+ActiveRecord::Schema[7.0].define(version: 2022_04_30_121719) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -67,7 +67,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_02_19_105635) do
   create_table "albums", force: :cascade do |t|
     t.string "title", null: false
     t.bigint "image_id"
-    t.date "release"
+    t.date "release", default: "0000-01-01", null: false
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.string "review_comment"

--- a/test/controllers/albums_controller_test.rb
+++ b/test/controllers/albums_controller_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class AlbumsControllerTest < ActionDispatch::IntegrationTest
   setup do
-    @album = create :album, :with_image, :with_release
+    @album = create :album, :with_image
     sign_in_as create(:user)
   end
 
@@ -21,7 +21,7 @@ class AlbumsControllerTest < ActionDispatch::IntegrationTest
 
   test 'should create album for moderator' do
     sign_in_as create(:moderator)
-    album = build :album, :with_release
+    album = build :album
 
     image = {
       data: Base64.encode64(File.read(Rails.root.join('test/files/image.jpg'))),
@@ -45,7 +45,7 @@ class AlbumsControllerTest < ActionDispatch::IntegrationTest
 
   test 'should not create album without title' do
     sign_in_as create(:moderator)
-    album = build :album, :with_release
+    album = build :album
 
     assert_difference('Album.count', 0) do
       post albums_url, params: { album: { release: album.release } }
@@ -56,7 +56,7 @@ class AlbumsControllerTest < ActionDispatch::IntegrationTest
 
   test 'should create dependent album_labels' do
     sign_in_as create(:moderator)
-    album = build :album, :with_release
+    album = build :album
 
     album_labels = (1..5).map do |_|
       {
@@ -81,7 +81,7 @@ class AlbumsControllerTest < ActionDispatch::IntegrationTest
 
   test 'should create dependent album_artists' do
     sign_in_as create(:moderator)
-    album = build :album, :with_release
+    album = build :album
 
     album_artists = (1..5).map do |i|
       {
@@ -140,7 +140,7 @@ class AlbumsControllerTest < ActionDispatch::IntegrationTest
 
   test 'should update album for moderator' do
     sign_in_as create(:moderator)
-    album = create :album, :with_release
+    album = create :album
 
     image = {
       data: Base64.encode64(File.read(Rails.root.join('test/files/image.jpg'))),
@@ -158,7 +158,7 @@ class AlbumsControllerTest < ActionDispatch::IntegrationTest
 
   test 'should destroy previous image when image is replaced' do
     sign_in_as create(:moderator)
-    album = create :album, :with_release, :with_image
+    album = create :album, :with_image
 
     image = {
       data: Base64.encode64(File.read(Rails.root.join('test/files/image.jpg'))),
@@ -178,7 +178,7 @@ class AlbumsControllerTest < ActionDispatch::IntegrationTest
 
   test 'should destroy previous image when image is cleared' do
     sign_in_as create(:moderator)
-    album = create :album, :with_release, :with_image
+    album = create :album, :with_image
 
     image = {
       data: nil,

--- a/test/factories/albums.rb
+++ b/test/factories/albums.rb
@@ -18,10 +18,7 @@ FactoryBot.define do
   factory :album do
     title { Faker::Music.album }
     review_comment { Faker::Lorem.word }
-
-    trait :with_release do
-      release { Faker::Date.backward(days: 365 * 100) }
-    end
+    release { Faker::Date.backward(days: 365 * 100) }
 
     trait :with_image do
       association :image, factory: :image

--- a/test/factories/albums.rb
+++ b/test/factories/albums.rb
@@ -6,7 +6,7 @@
 #  edition             :date
 #  edition_description :string
 #  normalized_title    :string           not null
-#  release             :date
+#  release             :date             default(Thu, 01 Jan 0000), not null
 #  review_comment      :string
 #  title               :string           not null
 #  created_at          :datetime         not null

--- a/test/models/album_test.rb
+++ b/test/models/album_test.rb
@@ -6,7 +6,7 @@
 #  edition             :date
 #  edition_description :string
 #  normalized_title    :string           not null
-#  release             :date
+#  release             :date             default(Thu, 01 Jan 0000), not null
 #  review_comment      :string
 #  title               :string           not null
 #  created_at          :datetime         not null


### PR DESCRIPTION
Fixes #323

In this PR I:
* Added not null and a default to the Album's `release` column
* Updated the factory and the usage of the albums factory
* Remove the default value of the release date in the rescan runner