### PR TITLE
Add actions to update flake.lock and build derivations

### DIFF
--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -1,0 +1,38 @@
+name: Cachix
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  packages:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: cachix/install-nix-action@v17
+      - name: Cachix
+        uses: cachix/cachix-action@v10
+        with:
+          name: accentor
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          skipPush: true
+      - run: nix build -L --no-link .#accentor-api
+      - run: nix build -L --no-link .#accentor-api.env
+      - run: nix eval --json ".#accentor-api.outPath" | sed 's/"\(.*\)"/\1/' | cachix push accentor
+      - run: nix eval --json ".#accentor-api.env.outPath" | sed 's/"\(.*\)"/\1/' | cachix push accentor
+  shell:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: cachix/install-nix-action@v17
+      - name: Cachix
+        uses: cachix/cachix-action@v10
+        with:
+          name: accentor
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          skipPush: true
+      - run: nix build -L --no-link .#devShells.$(nix eval --impure --expr "builtins.currentSystem").accentor-api
+      - run: nix eval --json ".#devShells.$(nix eval --impure --expr 'builtins.currentSystem').accentor-api.outPath" | sed 's/"\(.*\)"/\1/' | cachix push accentor

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,0 +1,57 @@
+name: Update
+
+on:
+  schedule:
+    - cron: '30 */2 * * *'
+  workflow_dispatch:
+
+jobs:
+  packages:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: cachix/install-nix-action@v17
+      - name: Cachix
+        uses: cachix/cachix-action@v10
+        with:
+          name: accentor
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          skipPush: true
+      - run: nix flake update
+      - run: nix build -L --no-link .#accentor-api
+      - run: nix build -L --no-link .#accentor-api.env
+      - run: nix eval --json ".#accentor-api.outPath" | sed 's/"\(.*\)"/\1/' | cachix push accentor
+      - run: nix eval --json ".#accentor-api.env.outPath" | sed 's/"\(.*\)"/\1/' | cachix push accentor
+  shell:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: cachix/install-nix-action@v17
+      - name: Cachix
+        uses: cachix/cachix-action@v10
+        with:
+          name: accentor
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          skipPush: true
+      - run: nix flake update
+      - run: nix build -L --no-link .#devShells.$(nix eval --impure --expr "builtins.currentSystem").accentor-api
+      - run: nix eval --json ".#devShells.$(nix eval --impure --expr 'builtins.currentSystem').accentor-api.outPath" | sed 's/"\(.*\)"/\1/' | cachix push accentor
+  commit:
+    runs-on: ubuntu-latest
+    needs: [packages, shell]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: cachix/install-nix-action@v17
+      - name: Cachix
+        uses: cachix/cachix-action@v10
+        with:
+          name: accentor
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          skipPush: true
+      - run: nix flake update
+      - uses: stefanzweifel/git-auto-commit-action@v4.14.1
+        with:
+          commit_message: "Update flake dependencies"

--- a/flake.lock
+++ b/flake.lock
@@ -10,11 +10,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1650201426,
-        "narHash": "sha256-u43Xf03ImFJWKLHddtjOpCJCHbuM0SQbb6FKR5NuFhk=",
+        "lastModified": 1652959711,
+        "narHash": "sha256-wpQhlE/NocxlU3jLiMoF1KYHOEFD5MEFJZkyXXVVef8=",
         "owner": "numtide",
         "repo": "devshell",
-        "rev": "cb76bc75a0ee81f2d8676fe681f268c48dbd380e",
+        "rev": "a5327cd01e58d2848c73062f2661278ad615748f",
         "type": "github"
       },
       "original": {
@@ -25,11 +25,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1649676176,
-        "narHash": "sha256-OWKJratjt2RW151VUlJPRALb7OU2S5s+f0vLj4o1bHM=",
+        "lastModified": 1652776076,
+        "narHash": "sha256-gzTw/v1vj4dOVbpBSJX4J0DwUR6LIyXo7/SuuTJp1kM=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "a4b154ebbdc88c8498a5c7b01589addc9e9cb678",
+        "rev": "04c1b180862888302ddfb2e3ad9eaa63afc60cf8",
         "type": "github"
       },
       "original": {
@@ -40,11 +40,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1650076401,
-        "narHash": "sha256-QGxadqKWICchuuLIF2QwmHPVaUk+qO33ml5p1wW4IyA=",
+        "lastModified": 1652885393,
+        "narHash": "sha256-YIgvvlk4iQ1Hi7KD9o5gsojc+ApB+jiH1d5stK8uXiw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "75ad56bdc927f3a9f9e05e3c3614c4c1fcd99fcb",
+        "rev": "48037fd90426e44e4bf03e6479e88a11453b9b66",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Successful run of the Cachix action (without the `branches: [ main ]` selector) can be found [here](https://github.com/accentor/api/actions/runs/2364245278).

Support for aarch64-darwin can be added in the near future if I understand [this](https://github.com/actions/runner/issues/805#issuecomment-1132966327) correctly.