### PR TITLE
Don't use bundix' gemset in devshell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -48,22 +48,33 @@
           default = accentor-api;
           accentor-api = pkgs.devshell.mkShell {
             name = "Accentor API";
-            packages = [
-              gems
-              (pkgs.lowPrio gems.wrappedRuby)
-              pkgs.bundix
-              pkgs.ffmpeg
-              pkgs.nixpkgs-fmt
-              pkgs.postgresql_14
+            imports = [ "${devshell}/extra/language/c.nix" ];
+            packages = with pkgs; [
+              (lowprio binutils)
+              findutils
+              gnumake
+              ruby_3_1
+              bundix
+              ffmpeg
+              nixpkgs-fmt
+              postgresql_14
             ];
             env = [
               {
+                name = "GEM_HOME";
+                eval = "$PRJ_DATA_DIR/bundle/$(ruby -e 'puts RUBY_VERSION')";
+              }
+              {
                 name = "PGDATA";
-                eval = "$PWD/tmp/postgres";
+                eval = "$PRJ_DATA_DIR/postgres";
               }
               {
                 name = "DATABASE_HOST";
                 eval = "$PGDATA";
+              }
+              {
+                name = "PATH";
+                prefix = "$GEM_HOME/bin";
               }
             ];
             commands = [
@@ -104,6 +115,7 @@
                 '';
               }
             ];
+            language.c.compiler = pkgs.gcc;
           };
         };
       }


### PR DESCRIPTION
It makes adding a dependency during local development unnecessarily difficult
and it doesn't really provide that much benefit as far as I can tell.

It's not perfect, since native dependencies in the gems can link to garbage-collected paths, but a `bundle pristine` fixes those.

Note that I don't necessarily need this change. If there is good reason to keep things as-is, that is also fine, but @rien struggled with the "adding-a-local-dependency" thing yesterday (on a different project).

This also moves the postgres data to the `PRJ_DATA_DIR` provided by devshell.