### PR TITLE
Attribute automated commits to accentor bot

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -55,3 +55,6 @@ jobs:
       - uses: stefanzweifel/git-auto-commit-action@v4.14.1
         with:
           commit_message: "Update flake dependencies"
+          commit_user_name:  Accentor Bot
+          commit_user_email: accentor-bot@users.noreply.github.com
+          commit_author: Accentor Bot <accentor-bot@users.noreply.github.com>


### PR DESCRIPTION
The current system to update the flake dependencies somehow picked me as the author of the commits ([example](https://github.com/accentor/api/commit/36a7b0f4c2d2fe183d696f6469bd3c920d554ae1)). This is a bit confusing 😅 

I propose to always attribute these changes [accentor-bot](https://github.com/accentor-bot)