### PR TITLE
Add command to auto-update `Gemfile.lock` and `gemset.nix`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -51,7 +51,6 @@
             packages = [
               gems
               (pkgs.lowPrio gems.wrappedRuby)
-              pkgs.bundix
               pkgs.ffmpeg
               pkgs.nixpkgs-fmt
               pkgs.postgresql_14
@@ -101,6 +100,15 @@
                 help = "Open database console";
                 command = ''
                   psql --host $PGDATA -U postgres
+                '';
+              }
+              {
+                name = "gems:update";
+                category = "dependencies";
+                help = "Update the `Gemfile.lock` and `gemset.nix` files";
+                command = ''
+                  ${pkgs.ruby_3_1}/bin/bundle lock
+                  ${pkgs.bundix}/bin/bundix
                 '';
               }
             ];


### PR DESCRIPTION
Re #337 

Adds an extra command `gems:update` to the devshell, so a user can easily bring the `Gemfile.lock` and `gemset.nix` up to date with the `Gemfile`.

I've also removed bundix from the packages exposed in the devshell, since I would recommend flake users to use this command.

Tested locally by adding a new gem to the gemfile and verifying that everything works

