### PR TITLE
Fix responses not being streamed

### DIFF
--- a/app/controllers/tracks_controller.rb
+++ b/app/controllers/tracks_controller.rb
@@ -109,6 +109,9 @@ class TracksController < ApplicationController
     response.content_type = mimetype
     response.headers['accept-ranges'] = 'bytes'
     response.headers['content-length'] = (last_byte - first_byte + 1).to_s
+    # Workaround for https://github.com/rack/rack/issues/1619
+    # Remove when rack 3.0 is released
+    response.headers['last-modified'] = Time.now.httpdate
 
     to_skip = first_byte
     while to_skip.positive?


### PR DESCRIPTION
The ETag calculation was still happening, so somewhat slow
responses (e.g. transcodes of an hour of music) could take a minute until first
byte sent. This means that clients time out when trying to stream these files.

Related: #215 #216
