### PR TITLE
Return error when creating double playlist items

### DIFF
--- a/app/models/playlist.rb
+++ b/app/models/playlist.rb
@@ -47,7 +47,7 @@ class Playlist < ApplicationRecord
 
     # Use `self.items.build` to make sure we first fully validate the playlist and items before saving
     # This makes sure that we correctly validate and return errors for double items
-    ids.map.with_index(1) { |id, i| self.items.build(item_id: id, item_type:, order: i) }
+    ids.map.with_index(1) { |id, i| items.build(item_id: id, item_type:, order: i) }
   end
 
   private
@@ -63,8 +63,6 @@ class Playlist < ApplicationRecord
     # When validating, we use `collect(&:item_id)` so we get the correct data
     # Regardless of whether the items were already saved
     doubles = items.collect(&:item_id).uniq!
-
-    return if doubles.nil?
-    errors.add(:items, 'item-ids-contains-double')
+    errors.add(:items, 'item-ids-contains-double') unless doubles.nil?
   end
 end

--- a/test/models/playlist_test.rb
+++ b/test/models/playlist_test.rb
@@ -24,6 +24,7 @@ class PlaylistTest < ActiveSupport::TestCase
     i1 = build(:playlist_item, order: 5)
     i2 = build(:playlist_item, order: 2)
     list = build(:playlist, playlist_type: :track, items: [i1, i2])
+    print list.items
     list.save
     assert_equal 2, i1.order
     assert_equal 1, i2.order
@@ -65,6 +66,14 @@ class PlaylistTest < ActiveSupport::TestCase
     assert_equal 2, list.items.length
     assert_equal t1, list.items.first.item
     assert_equal t2, list.items.second.item
+  end
+
+  test 'should not be valid if double item_id is present' do
+    track = create(:track)
+    list = build(:playlist, playlist_type: :track, item_ids: [track.id, track.id])
+
+    assert_not list.valid?
+    assert_not_empty list.errors['items']
   end
 
   test 'should return empty item_ids when using `with_item_ids` if there are no items' do

--- a/test/models/playlist_test.rb
+++ b/test/models/playlist_test.rb
@@ -21,18 +21,17 @@ class PlaylistTest < ActiveSupport::TestCase
   end
 
   test 'should normalize order of items' do
-    i1 = build(:playlist_item, order: 5)
-    i2 = build(:playlist_item, order: 2)
+    i1 = build(:playlist_item, order: 5, item: create(:track))
+    i2 = build(:playlist_item, order: 2, item: create(:track))
     list = build(:playlist, playlist_type: :track, items: [i1, i2])
-    print list.items
     list.save
     assert_equal 2, i1.order
     assert_equal 1, i2.order
   end
 
   test 'should leave order of track items alone if normalized' do
-    i1 = build(:playlist_item, order: 1)
-    i2 = build(:playlist_item, order: 2)
+    i1 = build(:playlist_item, order: 1, item: create(:track))
+    i2 = build(:playlist_item, order: 2, item: create(:track))
     list = build(:playlist, playlist_type: :track, items: [i1, i2])
     list.save
     assert_equal 1, i1.order
@@ -40,8 +39,8 @@ class PlaylistTest < ActiveSupport::TestCase
   end
 
   test 'should normalize order of items in order provided if equal' do
-    i1 = build(:playlist_item, order: 0)
-    i2 = build(:playlist_item, order: 0)
+    i1 = build(:playlist_item, order: 0, item: create(:track))
+    i2 = build(:playlist_item, order: 0, item: create(:track))
     list = build(:playlist, playlist_type: :track, items: [i1, i2])
     list.save
     assert_equal 1, i1.order


### PR DESCRIPTION
Fixes #351 

Our current way of setting the `items` through `item_ids` required some changes to make sure that it runs after the full playlist is modified. I've left some comments to explain the behaviour for ourselves in the future.

Matching PR in web will follow asap.

- [x] I've added tests relevant to my changes.

