### PR TITLE
Cache activestorage images forever

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -31,6 +31,8 @@ module Accentor
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
+    # Workaround for Rails bug
+    config.middleware.use ActionDispatch::Flash
 
     config.active_job.queue_adapter = :delayed_job
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,7 +31,7 @@ module Accentor
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
-    # Workaround for Rails bug
+    # Workaround for Rails bug. Reported at https://github.com/rails/rails/issues/45781/.
     config.middleware.use ActionDispatch::Flash
 
     config.active_job.queue_adapter = :delayed_job

--- a/config/initializers/active_storage.rb
+++ b/config/initializers/active_storage.rb
@@ -1,0 +1,4 @@
+# Proxy requests to active_storage blobs. This allows for much better caching
+# and requires one less round-trip. Since we store images on disk anyway, this
+# should not have any performance impact.
+Rails.application.config.active_storage.resolve_model_to_route = :rails_storage_proxy


### PR DESCRIPTION
Fixes https://github.com/accentor/android/issues/399.

