### PR TITLE
Precompile bootsnap during `buildPhase`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -35,6 +35,11 @@
 
             src = pkgs.lib.cleanSourceWith { filter = name: type: !(builtins.elem name [ ".github" "flake.lock" "flake.nix" ]); src = ./.; name = "source"; };
 
+            buildPhase = ''
+              # Compile bootsnap cache
+              ${gems}/bin/bundle exec bootsnap precompile --gemfile app/ lib/
+            '';
+
             installPhase = ''
               mkdir $out
               cp -r * $out


### PR DESCRIPTION
Moving the compilation to the buildPhase gives a small improvement when booting the app. The cache now gets compiled to a folder outside of the nix store during boot (or afterwards if code changes), but since the application's code can't change after build, the cache should also never change.

I've been using this change in some other rails apps, and this seems to work without much problems.
