### PR TITLE
Pass github token to `install-nix-action`

### DIFF
--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: cachix/install-nix-action@v18
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Cachix
         uses: cachix/cachix-action@v12
         with:
@@ -28,6 +30,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: cachix/install-nix-action@v18
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Cachix
         uses: cachix/cachix-action@v12
         with:

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -17,6 +17,7 @@ jobs:
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
       - uses: cachix/install-nix-action@v18
         with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
           nix_path: nixpkgs=channel:nixpkgs-unstable
       - name: Run bundix
         run: nix-shell -p bundix --run "bundix"

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: cachix/install-nix-action@v18
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Cachix
         uses: cachix/cachix-action@v12
         with:
@@ -30,6 +32,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: cachix/install-nix-action@v18
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Cachix
         uses: cachix/cachix-action@v12
         with:
@@ -45,6 +49,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: cachix/install-nix-action@v18
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Cachix
         uses: cachix/cachix-action@v12
         with:


### PR DESCRIPTION
Passing the `GITHUB_TOKEN` to `cachix/install-nix-action` should fix our actions failing due to github's rate limiting.