### PR TITLE
Keep image during merge of two artists

### DIFF
--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -48,6 +48,16 @@ class Artist < ApplicationRecord
       item.update(item_id: id) unless playlist_items.where(playlist_id: item.playlist_id).any?
     end
 
+    # Copy over the image if other has one and the current artist does not have one
+    if other.image.present? && image.nil?
+      image_id = other.image_id
+      # rubocop:disable Rails/SkipsModelValidations
+      # We have to skip validations and callbacks, so that the `Image` object doesn't get destroyed
+      other.update_column(:image_id, nil)
+      # rubocop:enable Rails/SkipsModelValidations
+      update(image_id:)
+    end
+
     # we have to reload to make sure the track_artists and album_artists relation isn't cached anymore
     other.reload.destroy
   end

--- a/test/models/artist_test.rb
+++ b/test/models/artist_test.rb
@@ -135,6 +135,28 @@ class ArtistTest < ActiveSupport::TestCase
     assert_not_empty artist2.errors[:album_artists]
   end
 
+  test 'should keep not override image during merge' do
+    artist1 = create(:artist, :with_image)
+    artist2 = create(:artist, :with_image)
+
+    assert_difference ['Image.count', 'ActiveStorage::Attachment.count'], -1 do
+      artist2.merge(artist1)
+    end
+
+    assert_predicate artist2.image, :present?
+  end
+
+  test 'should keep image from other during merge if target doesnt have one' do
+    artist1 = create(:artist, :with_image)
+    artist2 = create(:artist)
+
+    assert_no_difference 'Image.count', 'ActiveStorage::Attachment.count' do
+      artist2.merge(artist1)
+    end
+
+    assert_predicate artist2.image, :present?
+  end
+
   test 'should nilify blank review_comment' do
     track = build(:track, review_comment: '')
     track.save
@@ -142,7 +164,7 @@ class ArtistTest < ActiveSupport::TestCase
     assert_nil track.review_comment
   end
 
-  test 'should move playlist_items on merge' do
+  test 'should move playlist_items railon merge' do
     a1 = create(:artist)
     a2 = create(:artist)
     create(:playlist_item, :for_artist, item: a2)

--- a/test/models/artist_test.rb
+++ b/test/models/artist_test.rb
@@ -164,7 +164,7 @@ class ArtistTest < ActiveSupport::TestCase
     assert_nil track.review_comment
   end
 
-  test 'should move playlist_items railon merge' do
+  test 'should move playlist_items on merge' do
     a1 = create(:artist)
     a2 = create(:artist)
     create(:playlist_item, :for_artist, item: a2)


### PR DESCRIPTION
Fixes #346
With this PR, we will keep the image of an artist during merging, if the artist we are merging into doesn't have an image yet.

- [x] I've added tests relevant to my changes.
