### PR TITLE
Allow moderator and admin to merge albums

### DIFF
--- a/app/controllers/albums_controller.rb
+++ b/app/controllers/albums_controller.rb
@@ -1,5 +1,5 @@
 class AlbumsController < ApplicationController
-  before_action :set_album, only: %i[show update destroy]
+  before_action :set_album, only: %i[show update destroy merge]
 
   has_scope :by_filter, as: 'filter'
   has_scope :by_label, as: 'label'
@@ -45,6 +45,10 @@ class AlbumsController < ApplicationController
   def destroy_empty
     authorize Album
     Album.where.not(id: Track.select(:album_id).distinct).destroy_all
+  end
+
+  def merge
+    render json: @album.errors, status: :unprocessable_entity unless @album.merge(Album.find(params[:source_id]))
   end
 
   private

--- a/app/models/album.rb
+++ b/app/models/album.rb
@@ -40,6 +40,29 @@ class Album < ApplicationRecord
   scope :by_label, ->(label) { joins(:album_labels).where(album_labels: { label_id: label }) }
   scope :by_labels, ->(labels) { joins(:album_labels).where(album_labels: { label_id: labels }) }
 
+  def merge(other)
+    other.tracks.find_each do |track|
+      track.update(album_id: id)
+    end
+
+    other.playlist_items.find_each do |item|
+      item.update(item_id: id) unless playlist_items.where(playlist_id: item.playlist_id).any?
+    end
+
+    # Copy over the image if other has one and the current album does not have one
+    if other.image.present? && image.nil?
+      image_id = other.image_id
+      # rubocop:disable Rails/SkipsModelValidations
+      # We have to skip validations and callbacks, so that the `Image` object doesn't get destroyed
+      other.update_column(:image_id, nil)
+      # rubocop:enable Rails/SkipsModelValidations
+      update(image_id:)
+    end
+
+    # we have to reload to make sure the relations aren't cached anymore
+    other.reload.destroy
+  end
+
   private
 
   def normalize_artist_order

--- a/app/policies/album_policy.rb
+++ b/app/policies/album_policy.rb
@@ -29,6 +29,10 @@ class AlbumPolicy < ApplicationPolicy
     create?
   end
 
+  def merge?
+    create?
+  end
+
   def permitted_attributes
     if user.moderator?
       [

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -109,6 +109,9 @@ Rails.application.routes.draw do
       collection do
         post 'destroy_empty'
       end
+      member do
+        post 'merge'
+      end
       resources :tracks, only: [:index]
     end
     resources :artists do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@
 #
 #                          Prefix Verb   URI Pattern                                                                                       Controller#Action
 #            destroy_empty_albums POST   /api/albums/destroy_empty(.:format)                                                               albums#destroy_empty
+#                     merge_album POST   /api/albums/:id/merge(.:format)                                                                   albums#merge
 #                    album_tracks GET    /api/albums/:album_id/tracks(.:format)                                                            tracks#index
 #                          albums GET    /api/albums(.:format)                                                                             albums#index
 #                                 POST   /api/albums(.:format)                                                                             albums#create

--- a/test/controllers/albums_controller_test.rb
+++ b/test/controllers/albums_controller_test.rb
@@ -249,4 +249,25 @@ class AlbumsControllerTest < ActionDispatch::IntegrationTest
 
     assert_not_nil Album.find_by(id: album2.id)
   end
+
+  test 'should not merge albums for user' do
+    album = create(:album)
+
+    assert_difference('Album.count', 0) do
+      post merge_album_url(@album, source_id: album.id)
+    end
+
+    assert_response :forbidden
+  end
+
+  test 'should merge albums for moderator' do
+    sign_in_as(create(:moderator))
+    album = create(:album)
+
+    assert_difference('Album.count', -1) do
+      post merge_album_url(@album, source_id: album.id)
+    end
+
+    assert_response :success
+  end
 end


### PR DESCRIPTION
Since we have playlists, it has become relevant to merge albums.
We currently simply move over the tracks, playlist items and image (if the target does not yet have an image itself). All other info (album artists, labels, ...) is simply kept the same.

- [x] I've added tests relevant to my changes.
