### PR TITLE
Include `audio_file_id` in `TrackSerializer`

### DIFF
--- a/app/serializers/track_serializer.rb
+++ b/app/serializers/track_serializer.rb
@@ -13,7 +13,7 @@
 #  audio_file_id    :bigint
 #
 class TrackSerializer < ActiveModel::Serializer
-  attributes :id, :title, :normalized_title, :number, :album_id, :review_comment, :created_at, :updated_at, :genre_ids, :codec_id, :length, :bitrate, :location_id
+  attributes :id, :title, :normalized_title, :number, :album_id, :review_comment, :created_at, :updated_at, :genre_ids, :codec_id, :length, :bitrate, :location_id, :audio_file_id
 
   has_many :track_artists
 


### PR DESCRIPTION
This should make it easier to invalidate cached audio files, since the `audio_file_id` is tied to a file on disk - if the file changes, the id will change as well.

Fix #393

No additional tests added, since we don't test basic fields in the serializers

