### PR TITLE
Allow dependabot to update indirect dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,8 @@ version: 2
 updates:
 - package-ecosystem: bundler
   directory: "/"
+  allow:
+    - dependency-type: "all"
   schedule:
     interval: weekly
     day: saturday


### PR DESCRIPTION
Dependabot currently only suggests updates for the direct dependencies, and not for indirect dependencies. This PR also allows dependabot to update all dependencies.

For example: The rubocop gem will only be updated when either `rubocop-minitest` or `rubocop-rails` is updated. We might want to update `rubocop` in itself.

Note: we could specify specific dependencies or globs, for which this is or isn't the case, but that didn't seem worth the effort to me.