### PR TITLE
Make sure that content-length header can never be deleted

### DIFF
--- a/app/controllers/tracks_controller.rb
+++ b/app/controllers/tracks_controller.rb
@@ -116,6 +116,10 @@ class TracksController < ApplicationController
     response.content_type = mimetype
     response.headers['accept-ranges'] = 'bytes'
     response.headers['content-length'] = (last_byte - first_byte + 1).to_s
+    # Unfortunately, if we don't commit the headers, ActionController::Live will
+    # delete the "content-length" header set above. No other headers need to be
+    # set, so we just freeze them here.
+    response.commit!
 
     to_skip = first_byte
     while to_skip.positive?


### PR DESCRIPTION
Once the response is `commit`ted, the headers can't be edited anymore, which is exactly what we want in this case.

Unfortunately, this can't be added to the tests, because the way responses and `ActionController::Live` work in tests just doesn't allow it (in fact, the tests already "test" for the presence of this header, and the tests still succeed even though in production the header is not present).

Fixes #503.
