### PR TITLE
Enhc/add individual playlist items

### DIFF
--- a/app/controllers/playlist_items_controller.rb
+++ b/app/controllers/playlist_items_controller.rb
@@ -1,0 +1,8 @@
+class PlaylistItemsController < ApplicationController
+  def create
+    @item = PlaylistItem.new(permitted_attributes(PlaylistItem))
+    authorize @item
+
+    render json: @item.errors, status: :unprocessable_entity unless @item.save
+  end
+end

--- a/app/models/playlist_item.rb
+++ b/app/models/playlist_item.rb
@@ -29,6 +29,6 @@ class PlaylistItem < ApplicationRecord
   def set_order
     return if order.present?
 
-    self.order = self.playlist.items.count + 1
+    self.order = playlist.items.count + 1
   end
 end

--- a/app/models/playlist_item.rb
+++ b/app/models/playlist_item.rb
@@ -18,9 +18,17 @@ class PlaylistItem < ApplicationRecord
   validates :item_id, uniqueness: { scope: %i[playlist_id] }
   validate :item_type_should_match_playlist_type
 
+  before_validation :set_order
+
   private
 
   def item_type_should_match_playlist_type
     errors.add(:item, 'item-type-different-from-playlist-type') unless item_type.downcase == playlist.playlist_type
+  end
+
+  def set_order
+    return if order.present?
+
+    self.order = self.playlist.items.count + 1
   end
 end

--- a/app/policies/playlist_item_policy.rb
+++ b/app/policies/playlist_item_policy.rb
@@ -1,0 +1,9 @@
+class PlaylistItemPolicy < ApplicationPolicy
+  def create?
+    user.present? && (record.playlist&.shared? || record.playlist&.user_id == user.id)
+  end
+
+  def permitted_attributes
+    %i[playlist_id item_id item_type] if user.present?
+  end
+end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -55,7 +55,8 @@ Rails.application.configure do
   config.i18n.raise_on_missing_translations = true
 
   # Raise error when a before_action's only/except options reference missing actions
-  config.action_controller.raise_on_missing_callback_actions = true
+  # This is disabled since we have a global `index` action, but don't always have an index action
+  config.action_controller.raise_on_missing_callback_actions = false
 
   config.token_hash_rounds = 10
   config.ffmpeg_log_location = Rails.root.join('log/ffmpeg.log').to_s

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -53,7 +53,8 @@ Rails.application.configure do
   # config.action_view.annotate_rendered_view_with_filenames = true
 
   # Raise error when a before_action's only/except options reference missing actions
-  config.action_controller.raise_on_missing_callback_actions = true
+  # This is disabled since we have a global `index` action, but don't always have an index action
+  config.action_controller.raise_on_missing_callback_actions = false
 
   # For tests we want these settings to remain the same, regardless of the configuration in application.rb
   config.transcode_cache_expiry = -> { 1.day.ago }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -72,6 +72,7 @@
 #                                 PATCH  /api/playlists/:id(.:format)                                                                      playlists#update
 #                                 PUT    /api/playlists/:id(.:format)                                                                      playlists#update
 #                                 DELETE /api/playlists/:id(.:format)                                                                      playlists#destroy
+#                  playlist_items POST   /api/playlist_items(.:format)                                                                     playlist_items#create
 #                     stats_plays GET    /api/plays/stats(.:format)                                                                        plays#stats
 #                           plays GET    /api/plays(.:format)                                                                              plays#index
 #                                 POST   /api/plays(.:format)                                                                              plays#create
@@ -149,6 +150,7 @@ Rails.application.routes.draw do
     end
     resources :locations, only: %i[index show create destroy]
     resources :playlists
+    resources :playlist_items, only: %i[create]
     resources :plays, only: %i[index create] do
       collection do
         get 'stats'

--- a/test/controllers/playlist_items_controller_test.rb
+++ b/test/controllers/playlist_items_controller_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 class PlaylistItemsControllerTest < ActionDispatch::IntegrationTest
   setup do
@@ -16,16 +16,16 @@ class PlaylistItemsControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_response :unauthorized
-  end 
-  
+  end
+
   test 'should create playlist item in shared playlist' do
     assert_difference('PlaylistItem.count', 1) do
       post playlist_items_url, params: { playlist_item: { playlist_id: @playlist.id, item_id: @track.id, item_type: 'Track' } }
     end
 
     assert_response :created
-    assert_equal PlaylistItem.last.order, 1
-  end 
+    assert_equal 1, PlaylistItem.last.order
+  end
 
   test 'should create playlist item in personal playlist that belongs to user' do
     playlist = create(:playlist, access: :personal, playlist_type: :track, user: @user)
@@ -35,8 +35,8 @@ class PlaylistItemsControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_response :created
-    assert_equal PlaylistItem.last.order, 1
-  end 
+    assert_equal 1, PlaylistItem.last.order
+  end
 
   test 'should not create playlist item in personal playlist that does not belongs to user' do
     playlist = create(:playlist, access: :personal, playlist_type: :track)
@@ -46,5 +46,5 @@ class PlaylistItemsControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_response :forbidden
-  end 
+  end
 end

--- a/test/controllers/playlist_items_controller_test.rb
+++ b/test/controllers/playlist_items_controller_test.rb
@@ -1,0 +1,50 @@
+require "test_helper"
+
+class PlaylistItemsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = create(:user)
+    sign_in_as(@user)
+    @playlist = create(:playlist, access: :shared, playlist_type: :track)
+    @track = create(:track)
+  end
+
+  test 'should not create playlist item if no user' do
+    sign_out
+
+    assert_no_difference 'PlaylistItem.count' do
+      post playlist_items_url, params: { playlist_item: { playlist_id: @playlist.id, item_id: @track.id, item_type: 'Track' } }
+    end
+
+    assert_response :unauthorized
+  end 
+  
+  test 'should create playlist item in shared playlist' do
+    assert_difference('PlaylistItem.count', 1) do
+      post playlist_items_url, params: { playlist_item: { playlist_id: @playlist.id, item_id: @track.id, item_type: 'Track' } }
+    end
+
+    assert_response :created
+    assert_equal PlaylistItem.last.order, 1
+  end 
+
+  test 'should create playlist item in personal playlist that belongs to user' do
+    playlist = create(:playlist, access: :personal, playlist_type: :track, user: @user)
+
+    assert_difference('PlaylistItem.count', 1) do
+      post playlist_items_url, params: { playlist_item: { playlist_id: playlist.id, item_id: @track.id, item_type: 'Track' } }
+    end
+
+    assert_response :created
+    assert_equal PlaylistItem.last.order, 1
+  end 
+
+  test 'should not create playlist item in personal playlist that does not belongs to user' do
+    playlist = create(:playlist, access: :personal, playlist_type: :track)
+
+    assert_no_difference 'PlaylistItem.count' do
+      post playlist_items_url, params: { playlist_item: { playlist_id: playlist.id, item_id: @track.id, item_type: 'Track' } }
+    end
+
+    assert_response :forbidden
+  end 
+end

--- a/test/models/playlist_item_test.rb
+++ b/test/models/playlist_item_test.rb
@@ -28,4 +28,13 @@ class PlayListItemTest < ActiveSupport::TestCase
     assert_not_predicate item, :valid?
     assert_not_empty item.errors[:item]
   end
+
+  test 'item should get order if not present' do
+    playlist = create(:playlist, playlist_type: :album)
+    item = build(:playlist_item, :for_track, playlist:, order: nil)
+
+    item.validate
+
+    assert_equal item.order, 1
+  end
 end

--- a/test/models/playlist_item_test.rb
+++ b/test/models/playlist_item_test.rb
@@ -35,6 +35,6 @@ class PlayListItemTest < ActiveSupport::TestCase
 
     item.validate
 
-    assert_equal item.order, 1
+    assert_equal 1, item.order
   end
 end


### PR DESCRIPTION
Adding a single playlist item to an existing playlist through `PlaylistsController#update` takes longer and longer, the more items there are (since we destroy and create all items). This PR adds an additional endpoint to simply create a playlist item.

Two choices I made:
* A user is not able to specify the order. The item always gets added as the last item in the list
* The user (but more realistically: the client the user is using) does need to specify the type of item, to check that it matches the playlist's type.

- [x] I've added tests relevant to my changes.

