### PR TITLE
Enable rails health check in routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -96,6 +96,7 @@
 #                          rescan GET    /api/rescans/:id(.:format)                                                                        rescans#show
 #                                 POST   /api/rescans/:id(.:format)                                                                        rescans#start
 #                                 POST   /api/rescans(.:format)                                                                            rescans#start_all
+#              rails_health_check GET    /api/up(.:format)                                                                                 rails/health#show
 #              rails_service_blob GET    /rails/active_storage/blobs/redirect/:signed_id/*filename(.:format)                               active_storage/blobs/redirect#show
 #        rails_service_blob_proxy GET    /rails/active_storage/blobs/proxy/:signed_id/*filename(.:format)                                  active_storage/blobs/proxy#show
 #                                 GET    /rails/active_storage/blobs/:signed_id/*filename(.:format)                                        active_storage/blobs/redirect#show
@@ -173,5 +174,7 @@ Rails.application.routes.draw do
     resources :rescans, only: %i[index show]
     post 'rescans/:id', to: 'rescans#start'
     post 'rescans', to: 'rescans#start_all'
+
+    get 'up', to: 'rails/health#show', as: :rails_health_check
   end
 end


### PR DESCRIPTION
This PR adds the default rails health check as an endpoint in the routes. This allows us to setup some kind of uptime monitoring, without calling any of our actual controllers. In theory, we could also have clients (especially those with an audio cahce) check this before making any actual requests for new data.

From [the docs](https://api.rubyonrails.org/classes/Rails/HealthController.html):
> This endpoint will return a 200 status code if the app has booted with no exceptions, and a 500 status code otherwise.

Example request:
```sh
$ curl localhost:3000/api/up --verbose             
*   Trying [::1]:3000...
* Connected to localhost (::1) port 3000
> GET /api/up HTTP/1.1
> Host: localhost:3000
> User-Agent: curl/8.4.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< x-frame-options: SAMEORIGIN
< x-xss-protection: 0
< x-content-type-options: nosniff
< x-permitted-cross-domain-policies: none
< referrer-policy: strict-origin-when-cross-origin
< x-api-version: 0.20.0
< content-type: text/html; charset=utf-8
< vary: Accept, Origin
< etag: W/"7e6c9877b2dec7dfadc43e742246d94d"
< cache-control: max-age=0, private, must-revalidate
< x-request-id: 6b2f8970-cbac-4a8f-a4bc-39174fef2e4b
< x-runtime: 0.019172
< server-timing: start_processing.action_controller;dur=0.01, render_template.action_view;dur=0.01, process_action.action_controller;dur=0.26
< Content-Length: 73
< 
* Connection #0 to host localhost left intact
<!DOCTYPE html><html><body style="background-color: green"></body></html>%     
```