### PR TITLE
Add `ruby-lsp` to development gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,4 +52,5 @@ group :development do
   gem 'rubocop-factory_bot', '~> 2.25'
   gem 'rubocop-minitest', '~> 0.35.0'
   gem 'rubocop-rails', '~> 2.24'
+  gem 'ruby-lsp', '~> 0.16.6'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -176,6 +176,7 @@ GEM
       ast (~> 2.4.1)
       racc
     pg (1.5.6)
+    prism (0.27.0)
     psych (5.1.2)
       stringio
     puma (6.4.2)
@@ -254,6 +255,10 @@ GEM
       rack (>= 1.1)
       rubocop (>= 1.33.0, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
+    ruby-lsp (0.16.6)
+      language_server-protocol (~> 3.17.0)
+      prism (>= 0.23.0, < 0.28)
+      sorbet-runtime (>= 0.5.10782)
     ruby-progressbar (1.13.0)
     ruby-vips (2.1.4)
       ffi (~> 1.12)
@@ -264,6 +269,7 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.3)
+    sorbet-runtime (0.5.11372)
     stringio (3.1.0)
     thor (1.3.1)
     timeout (0.4.1)
@@ -302,6 +308,7 @@ DEPENDENCIES
   rubocop-factory_bot (~> 2.25)
   rubocop-minitest (~> 0.35.0)
   rubocop-rails (~> 2.24)
+  ruby-lsp (~> 0.16.6)
   simplecov (~> 0.21)
   tzinfo-data
   wahwah (~> 1.5.1)
@@ -311,4 +318,4 @@ RUBY VERSION
    ruby 3.3.0p0
 
 BUNDLED WITH
-   2.5.3
+   2.5.9

--- a/gemset.nix
+++ b/gemset.nix
@@ -676,6 +676,16 @@
     };
     version = "1.5.6";
   };
+  prism = {
+    groups = ["default" "development"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0xqvz4xkys5876q9sfd8kb0i4pviahzd0g04qqz91py63i7hp3gn";
+      type = "gem";
+    };
+    version = "0.27.0";
+  };
   psych = {
     dependencies = ["stringio"];
     groups = ["default" "development" "test"];
@@ -944,6 +954,17 @@
     };
     version = "2.24.1";
   };
+  ruby-lsp = {
+    dependencies = ["language_server-protocol" "prism" "sorbet-runtime"];
+    groups = ["development"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1k4makdihhr9srd2jy2xwwv7liz1zmhj3f56z36balgzlry37zgf";
+      type = "gem";
+    };
+    version = "0.16.6";
+  };
   ruby-progressbar = {
     groups = ["default" "development"];
     platforms = [];
@@ -1005,6 +1026,16 @@
       type = "gem";
     };
     version = "0.1.3";
+  };
+  sorbet-runtime = {
+    groups = ["default" "development"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1xgimysgv0rng9zn0xdgwfrcj3w9j7j3qz0bcdbyf57vizyp3xqf";
+      type = "gem";
+    };
+    version = "0.5.11372";
   };
   stringio = {
     groups = ["default" "development" "test"];


### PR DESCRIPTION
This adds [`ruby-lsp`](https://github.com/Shopify/ruby-lsp) to the development gems, so we can easily have syntax highlighting, better autocomplete, ...

I'd want to include this gem explicitly, since its usual editor integration doesn't work (well) with nix-based devshells (since it still needs to add a dependency to the PATH).