### PR TITLE
Add rubocop explicitly as a dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,7 @@ end
 
 group :development do
   gem 'annotate', '~> 3.2' # Remove workaround in lib/tasks/annotate.rb when https://github.com/ctran/annotate_models/issues/696 is fixed
+  gem 'rubocop', '~> 1.64'
   gem 'rubocop-factory_bot', '~> 2.26'
   gem 'rubocop-minitest', '~> 0.35.0'
   gem 'rubocop-rails', '~> 2.25'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -307,6 +307,7 @@ DEPENDENCIES
   pundit (~> 2.3)
   rack-cors (~> 2.0)
   rails (~> 7.1)
+  rubocop (~> 1.64)
   rubocop-factory_bot (~> 2.26)
   rubocop-minitest (~> 0.35.0)
   rubocop-rails (~> 2.25)


### PR DESCRIPTION
It would be nice to have the release notes for rubocop updates in Dependabot's PRs, and we would still want to use it even if we remove the other more specialized sets of cops.