### PR TITLE
Use `resize_to_cover` instead of `resize_to_fit` for all images

### DIFF
--- a/app/serializers/album_serializer.rb
+++ b/app/serializers/album_serializer.rb
@@ -32,21 +32,21 @@ class AlbumSerializer < ActiveModel::Serializer
     return nil if object.image.blank?
     return nil unless object.image.image.variable?
 
-    rails_representation_url(object.image.image.variant(resize_to_limit: [100, 100]), **scope)
+    rails_representation_url(object.image.image.variant(resize_to_cover: [100, 100]), **scope)
   end
 
   def image250
     return nil if object.image.blank?
     return nil unless object.image.image.variable?
 
-    rails_representation_url(object.image.image.variant(resize_to_limit: [250, 250]), **scope)
+    rails_representation_url(object.image.image.variant(resize_to_cover: [250, 250]), **scope)
   end
 
   def image500
     return nil if object.image.blank?
     return nil unless object.image.image.variable?
 
-    rails_representation_url(object.image.image.variant(resize_to_limit: [500, 500]), **scope)
+    rails_representation_url(object.image.image.variant(resize_to_cover: [500, 500]), **scope)
   end
 
   def image_type

--- a/app/serializers/artist_serializer.rb
+++ b/app/serializers/artist_serializer.rb
@@ -26,21 +26,21 @@ class ArtistSerializer < ActiveModel::Serializer
     return nil if object.image.blank?
     return nil unless object.image.image.variable?
 
-    rails_representation_url(object.image.image.variant(resize_to_limit: [100, 100]), **scope)
+    rails_representation_url(object.image.image.variant(resize_to_cover: [100, 100]), **scope)
   end
 
   def image250
     return nil if object.image.blank?
     return nil unless object.image.image.variable?
 
-    rails_representation_url(object.image.image.variant(resize_to_limit: [250, 250]), **scope)
+    rails_representation_url(object.image.image.variant(resize_to_cover: [250, 250]), **scope)
   end
 
   def image500
     return nil if object.image.blank?
     return nil unless object.image.image.variable?
 
-    rails_representation_url(object.image.image.variant(resize_to_limit: [500, 500]), **scope)
+    rails_representation_url(object.image.image.variant(resize_to_cover: [500, 500]), **scope)
   end
 
   def image_type


### PR DESCRIPTION
Our current usage of `resize_to_fit` doesn't really fit the way we display images. We are guaranteed a the maximum of the biggest dimension, but this means we can't be sure of the size of the smallest dimension. We places these images in cards where assume that they can be shown at ± the dimensions of the resize. This can result in low quality results when the image has a high aspect ratio. 

For example: I recently added an image that has a ratio of 3/1 , this is 500px x 167px after using `resize_to_fit: [500, 500]`. If this is displayed at 500px/500px, the image won't be shown at a decent quality. If we use `resize_to_cover: [500, 500]` the result will be 1500px x 500px, so it can be safely placed in a 500px/500px container. (This was sadly the only image provided as album artwork.)

Two downsides:
* This will result in larger files for every image that is not a square (Though only slightly larger if the ratio is close to 1/1)
* This will result in new images urls for ALL images on the server, which might cause a temporary extra load the server. We _could_ mitigate this with some A/B paths, so we can roll out this change over a period of time. I don't think that extra code is worth it.

- [ ] I've added tests relevant to my changes.
