### PR TITLE
Add optional `application` attribute to auth tokens

### DIFF
--- a/app/controllers/auth_tokens_controller.rb
+++ b/app/controllers/auth_tokens_controller.rb
@@ -25,7 +25,7 @@ class AuthTokensController < ApplicationController
     end
 
     @auth_token = AuthToken.new(
-      { user_agent: request.headers[:'user-agent'] }
+      { user_agent: request.headers[:'user-agent'], application: params[:application] }
           .merge(params[:auth_token].present? ? permitted_attributes(AuthToken) : {})
           .merge(user:)
     )

--- a/app/controllers/auth_tokens_controller.rb
+++ b/app/controllers/auth_tokens_controller.rb
@@ -25,7 +25,7 @@ class AuthTokensController < ApplicationController
     end
 
     @auth_token = AuthToken.new(
-      { user_agent: request.headers[:'user-agent'], application: params[:application] }
+      { user_agent: request.headers[:'user-agent'] }
           .merge(params[:auth_token].present? ? permitted_attributes(AuthToken) : {})
           .merge(user:)
     )

--- a/app/models/auth_token.rb
+++ b/app/models/auth_token.rb
@@ -3,6 +3,7 @@
 # Table name: auth_tokens
 #
 #  id            :bigint           not null, primary key
+#  application   :string
 #  hashed_secret :string           not null
 #  user_agent    :string           not null
 #  device_id     :string           not null

--- a/app/policies/auth_token_policy.rb
+++ b/app/policies/auth_token_policy.rb
@@ -22,6 +22,6 @@ class AuthTokenPolicy < ApplicationPolicy
   end
 
   def permitted_attributes
-    [:user_agent]
+    %i[user_agent application]
   end
 end

--- a/app/serializers/auth_token_serializer.rb
+++ b/app/serializers/auth_token_serializer.rb
@@ -3,11 +3,12 @@
 # Table name: auth_tokens
 #
 #  id            :bigint           not null, primary key
+#  application   :string
 #  hashed_secret :string           not null
 #  user_agent    :string           not null
 #  device_id     :string           not null
 #  user_id       :bigint           not null
 #
 class AuthTokenSerializer < ActiveModel::Serializer
-  attributes :id, :device_id, :user_id, :user_agent
+  attributes :id, :device_id, :user_id, :user_agent, :application
 end

--- a/db/migrate/20240817081958_add_application_to_auth_tokens.rb
+++ b/db/migrate/20240817081958_add_application_to_auth_tokens.rb
@@ -1,0 +1,5 @@
+class AddApplicationToAuthTokens < ActiveRecord::Migration[7.2]
+  def change
+    add_column :auth_tokens, :application, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_06_100659) do
+ActiveRecord::Schema[7.2].define(version: 2024_08_17_081958) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -107,6 +107,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_06_100659) do
     t.string "device_id", null: false
     t.string "hashed_secret", null: false
     t.string "user_agent", null: false
+    t.string "application"
     t.index ["device_id"], name: "index_auth_tokens_on_device_id", unique: true
     t.index ["user_id"], name: "index_auth_tokens_on_user_id"
   end

--- a/test/factories/auth_tokens.rb
+++ b/test/factories/auth_tokens.rb
@@ -3,6 +3,7 @@
 # Table name: auth_tokens
 #
 #  id            :bigint           not null, primary key
+#  application   :string
 #  hashed_secret :string           not null
 #  user_agent    :string           not null
 #  device_id     :string           not null

--- a/test/models/auth_token_test.rb
+++ b/test/models/auth_token_test.rb
@@ -3,6 +3,7 @@
 # Table name: auth_tokens
 #
 #  id            :bigint           not null, primary key
+#  application   :string
 #  hashed_secret :string           not null
 #  user_agent    :string           not null
 #  device_id     :string           not null


### PR DESCRIPTION
While working on a separate frontend app, I noticed that we use the `user_agent` attribute a bit inconsistent. For browser apps we track the actual user agent, but for native apps we use this to track the device info and the app info. 
A user can't currently distinguish two browser apps in their auth tokens, since they both just show the user agent string.

This PR allows us to separately track the application and the device/OS that is used for the auth token. I'd propose that:
* `application` is for the app and its version. Eg. `Accentor 0.14.1 on android`, `web 0.1.2`, ... 
* `user_agent` is for the device/OS/browser used. For browser apps this can remain the same, for native apps it could be something like `macOS 14.5 (Build 23F79)` or `Android 13 on Fairphone 4`
For both of these, I wouldn't define a fixed format - as long as the right info is in the right field

I've made this attribute optional, so we can slowly roll out support in various apps. Maybe in time we could make this required?

## Two questions/points of discussion:
* `application` feels a bit generic, but I couldn't come up with anything specific
* I currently get this info from a param. I'd also be ok with defining a specific header to be used (or a combination of both, like for user agent).

- [ ] I've added tests relevant to my changes.
I've not added a test, since our controller tests don't check the attributes of the objects that are created.

