### PR TITLE
Remove obsolete `check_file_attributes` method

### DIFF
--- a/app/models/audio_file.rb
+++ b/app/models/audio_file.rb
@@ -36,13 +36,6 @@ class AudioFile < ApplicationRecord
     false
   end
 
-  def check_file_attributes
-    return unless check_self
-
-    tag = WahWah.open(full_path)
-    update(length: tag.duration, bitrate: tag.bitrate || 0, sample_rate: tag.sample_rate || 0, bit_depth: tag.bit_depth || 0)
-  end
-
   def convert(codec_conversion)
     parameters = codec_conversion.ffmpeg_params.split
     stdin, stdout, = Open3.popen2(

--- a/test/models/audio_file_test.rb
+++ b/test/models/audio_file_test.rb
@@ -21,16 +21,6 @@ class AudioFileTest < ActiveSupport::TestCase
     @audio_file = AudioFile.create(bitrate: 0, filename: 'base.flac', length: 100, codec:, location:, sample_rate: 0, bit_depth: 0)
   end
 
-  test 'check_file should add sample_rate and bit_depth' do
-    @audio_file.check_file_attributes
-    @audio_file.reload
-
-    assert_equal 48_000, @audio_file.sample_rate
-    assert_equal 16, @audio_file.bit_depth
-    assert_equal 768, @audio_file.bitrate
-    assert_equal 0, @audio_file.length
-  end
-
   test 'convert should not crash' do
     stdin = StringIO.new
     stdout = StringIO.new Rails.root.join('test/files/base.flac').read


### PR DESCRIPTION
This was only used in a migration, and new deployments will not actually need it.