### PR TITLE
Make sure we wait for ffmpeg to finish when transcoding

### DIFF
--- a/app/models/audio_file.rb
+++ b/app/models/audio_file.rb
@@ -46,7 +46,10 @@ class AudioFile < ApplicationRecord
       '-map', 'a',
       out_file_name,
       err: [Rails.configuration.ffmpeg_log_location, 'a']
-    )
+    ) do |_stdin, _stdout, _wait_thr|
+      # We call `Open3.popen2` with an empty block, so the process finishes before we return
+      # This returns `Process::Status`
+    end
   end
 
   def full_path


### PR DESCRIPTION
This fixes an issue from #644 where our `AudioFile#convert` would return before ffmpeg finishes.
There are a few other ways to accomplish the same thing, but an empty block with a clear note

- [ ] I've added tests relevant to my changes.

I did a manual test with the biggest audio file on my computer (1h20), so I could clearly see the effect of these changes