### PR TITLE
Use ruby that supports jemalloc

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
         pkgs = import nixpkgs { inherit system; overlays = [ devshell.overlays.default ]; };
         gems = pkgs.bundlerEnv rec {
           name = "accentor-api-env";
-          ruby = pkgs.ruby_3_3;
+          ruby = pkgs.ruby_3_3.override { jemallocSupport = true; };
           gemfile = ./Gemfile;
           lockfile = ./Gemfile.lock;
           gemset = ./gemset.nix;


### PR DESCRIPTION
In production, memory usage of the server can be steadily increased by performing an activestorage request in an infinite loop. The issue can be reproduced in development (though it is less pronounced)

When using a ruby configured with jemalloc, the issue is no longer reproducible in development. So I'm hoping that the same will be true in production.

