### PR TITLE
Switch to signed token to authenticate users

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -32,6 +32,7 @@ class ApplicationController < ActionController::API
 
   def authenticate_user
     token = authenticate_with_http_token { |it| AuthToken.find_by_token_for(:api, it) }
+    token ||= AuthToken.find_by_token_for(:api, params[:token])
 
     # While the various clients switch to the authorization header, we also accept the token using the secret header/param
     token ||= AuthToken.find_by_token_for(:api, request.headers[:'x-secret'] || params[:secret])

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,9 +1,10 @@
 class ApplicationController < ActionController::API
   include Pundit::Authorization
+  include ActionController::HttpAuthentication::Token::ControllerMethods
 
   attr_accessor :current_user
 
-  before_action :authenticate_from_token
+  before_action :authenticate_user
   after_action :verify_authorized
   # rubocop:disable Rails/LexicallyScopedActionFilter
   # Most subclasses will have this action, if they don't we also don't need to
@@ -29,13 +30,22 @@ class ApplicationController < ActionController::API
 
   private
 
-  def authenticate_from_token
-    token = AuthToken.find_authenticated(
-      {
-        secret: request.headers[:'x-secret'] || params[:secret],
-        device_id: request.headers[:'x-device-id'] || params[:device_id]
-      }
-    )
+  def authenticate_user
+    token = authenticate_with_http_token { |it| AuthToken.find_by_token_for(:api, it) }
+
+    # While the various clients switch to the authorization header, we also accept the token using the secret header/param
+    token ||= AuthToken.find_by_token_for(:api, request.headers[:'x-secret'] || params[:secret])
+
+    # As a fallback, we still allow users to log in with their device_id and secret
+    if token.nil?
+      token = AuthToken.find_authenticated(
+        {
+          secret: request.headers[:'x-secret'] || params[:secret],
+          device_id: request.headers[:'x-device-id'] || params[:device_id]
+        }
+      )
+    end
+
     self.current_user = token&.user
   end
 

--- a/app/controllers/auth_tokens_controller.rb
+++ b/app/controllers/auth_tokens_controller.rb
@@ -32,7 +32,7 @@ class AuthTokensController < ApplicationController
     )
 
     if @auth_token.save
-      render json: transform_auth_token_for_json_with_secret(@auth_token), status: :created
+      render json: transform_auth_token_for_json_with_token(@auth_token), status: :created
     else
       render json: @auth_token.errors, status: :unprocessable_entity
     end
@@ -53,9 +53,12 @@ class AuthTokensController < ApplicationController
     %i[id device_id user_id user_agent application].index_with { |it| auth_token.send(it) }
   end
 
-  def transform_auth_token_for_json_with_secret(auth_token)
+  def transform_auth_token_for_json_with_token(auth_token)
     result = transform_auth_token_for_json(auth_token)
-    result[:secret] = auth_token.secret
+    result[:token] = auth_token.generate_token_for(:api)
+
+    # While clients switch to the new token, we also send the token using the secret attribute
+    result[:secret] = result[:token]
     result
   end
 end

--- a/app/models/auth_token.rb
+++ b/app/models/auth_token.rb
@@ -30,6 +30,8 @@ class AuthToken < ApplicationRecord
 
   attr_accessor :secret
 
+  generates_token_for :api, &:device_id
+
   def self.find_authenticated(credentials)
     token = find_by(device_id: credentials[:device_id])
     token if token&.secret_correct?(credentials[:secret])

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -62,46 +62,43 @@ class ActiveSupport::TestCase
 end
 
 module SignInHelper
-  attr_accessor :credentials
+  attr_accessor :api_token
 
   def sign_in_as(user)
-    auth_token = create(:auth_token, user:)
-    self.credentials = { 'x-device-id': auth_token.device_id, 'x-secret': auth_token.secret }
+    self.api_token = create(:auth_token, user:).generate_token_for(:api)
   end
 
   def sign_out
-    self.credentials = {}
+    self.api_token = nil
   end
 
-  def merge_args(args)
-    args ||= {}
-    args[:headers] = args[:headers] || {}
-    creds = credentials || {}
-    { as: :json }.merge(args || {}).merge(headers: creds.merge(args[:headers]))
+  def merge_args(**args)
+    headers = { Authorization: "Bearer #{api_token}" }.merge(args.fetch(:headers, {}))
+    { as: :json }.merge(args).merge(headers:)
   end
 
-  def get(path, **args)
-    process(:get, path, **merge_args(args))
+  def get(path, **)
+    process(:get, path, **merge_args(**))
   end
 
-  def post(path, **args)
-    process(:post, path, **merge_args(args))
+  def post(path, **)
+    process(:post, path, **merge_args(**))
   end
 
-  def patch(path, **args)
-    process(:patch, path, **merge_args(args))
+  def patch(path, **)
+    process(:patch, path, **merge_args(**))
   end
 
-  def put(path, **args)
-    process(:put, path, **merge_args(args))
+  def put(path, **)
+    process(:put, path, **merge_args(**))
   end
 
-  def delete(path, **args)
-    process(:delete, path, **merge_args(args))
+  def delete(path, **)
+    process(:delete, path, **merge_args(**))
   end
 
-  def head(path, **args)
-    process(:head, path, **merge_args(args))
+  def head(path, **)
+    process(:head, path, **merge_args(**))
   end
 end
 


### PR DESCRIPTION
This PR switched our authentication method from with our device_id and secret to [rails' `generates_token_for`](https://api.rubyonrails.org/classes/ActiveRecord/TokenFor/ClassMethods.html#method-i-generates_token_for).

To avoid clients having to switch immediately, we send the token as if it was the secret and accept the `x-secret` header (or secret param). We also still allow clients to pass the device_id and secret.

## Motivation
My biggest reason for changing is performance. Every api request currently has to go through authentication. In our current implementation, we have to go through bcrypt to check the secret. By switching to `generates_token_for` we only have to check that the signature matches. Considering the amount a requests a user will send to get all albums, artists, tracks, plays, ... from the API - we can get big win if we can speed up each request.

Doing some local request on my dev machine, I can see a big difference for every request. After a few requests of warm up, I get the a ±50% reduction in average request durations. (Note that this wasn't a very scientific test, but just me watching the response times across a bunch of requests for the same controller/action).
* `find_authenticated`: ±100ms
* `find_by_token_for`: ±50ms

We can also see this difference when benchmarking these two methods directly:
```ruby
require 'benchmark'
auth_token = FactoryBot.create(:auth_token)
credentials = { device_id: auth_token.device_id, secret: auth_token.secret }
token = auth_token.generate_token_for(:api)
n = 1000
Benchmark.bmbm do |b|
  b.report("device id + secret") do
    n.times { AuthToken.find_authenticated(credentials) }
  end
  b.report("find_by_token_for") do
    n.times { AuthToken.find_by_token_for(:api, token) }
  end
end
```
```
Rehearsal ------------------------------------------------------
device id + secret  59.289659   0.272631  59.562290 ( 60.044401)
find_by_token_for    0.071776   0.028643   0.100419 (  0.156472)
-------------------------------------------- total: 59.662709sec

                         user     system      total        real
device id + secret  59.029725   0.211262  59.240987 ( 59.538001)
find_by_token_for    0.062914   0.006196   0.069110 (  0.094305)
```

## Format of token
The generated token is of the following format:
```
eyJfcmFpbHMiOnsiZGF0YSI6WzMxLCJmOTM4YjI4YmE0NTdhZDdhMTQ1MGFlYWQiXSwicHVyIjoiQXV0aFRva2VuXG5hcGlcbiJ9fQ==--8635f004299e3933f123665f8e4aadd05362c6a6
```
The base64 encoded json contains the AuthToken's id and device_id.
```
{"_rails"=>{"data"=>[31, "f938b28ba457ad7a1450aead"], "pur"=>"AuthToken\napi\n"}}
``` 

For someone to guess a token they would have to:
* Guess the device_id that matches the AuthToken's id
* Have the correct signature for this message

- [x] I've added tests relevant to my changes.

I ran a manual test with the current web client. When signing in, we still fetch all data and can play audio
