### PR TITLE
Replace `unprocessable_entity` with `unprocessable_content`

### DIFF
--- a/app/controllers/albums_controller.rb
+++ b/app/controllers/albums_controller.rb
@@ -29,7 +29,7 @@ class AlbumsController < ApplicationController
     if @album.save
       render json: transform_album_for_json(@album), status: :created
     else
-      render json: @album.errors, status: :unprocessable_entity
+      render json: @album.errors, status: :unprocessable_content
     end
   end
 
@@ -37,12 +37,12 @@ class AlbumsController < ApplicationController
     if @album.update(transformed_attributes)
       render json: transform_album_for_json(@album), status: :ok
     else
-      render json: @album.errors, status: :unprocessable_entity
+      render json: @album.errors, status: :unprocessable_content
     end
   end
 
   def destroy
-    render json: @album.errors, status: :unprocessable_entity unless @album.destroy
+    render json: @album.errors, status: :unprocessable_content unless @album.destroy
   end
 
   def destroy_empty
@@ -51,7 +51,7 @@ class AlbumsController < ApplicationController
   end
 
   def merge
-    render json: @album.errors, status: :unprocessable_entity unless @album.merge(Album.find(params[:source_id]))
+    render json: @album.errors, status: :unprocessable_content unless @album.merge(Album.find(params[:source_id]))
   end
 
   private

--- a/app/controllers/artists_controller.rb
+++ b/app/controllers/artists_controller.rb
@@ -26,7 +26,7 @@ class ArtistsController < ApplicationController
     if @artist.save
       render json: transform_artist_for_json(@artist), status: :created
     else
-      render json: @artist.errors, status: :unprocessable_entity
+      render json: @artist.errors, status: :unprocessable_content
     end
   end
 
@@ -34,12 +34,12 @@ class ArtistsController < ApplicationController
     if @artist.update(transformed_attributes)
       render json: transform_artist_for_json(@artist), status: :ok
     else
-      render json: @artist.errors, status: :unprocessable_entity
+      render json: @artist.errors, status: :unprocessable_content
     end
   end
 
   def destroy
-    render json: @artist.errors, status: :unprocessable_entity unless @artist.destroy
+    render json: @artist.errors, status: :unprocessable_content unless @artist.destroy
   end
 
   def destroy_empty
@@ -51,7 +51,7 @@ class ArtistsController < ApplicationController
   end
 
   def merge
-    render json: @artist.errors, status: :unprocessable_entity unless @artist.merge(Artist.find(params[:source_id]))
+    render json: @artist.errors, status: :unprocessable_content unless @artist.merge(Artist.find(params[:source_id]))
   end
 
   private

--- a/app/controllers/auth_tokens_controller.rb
+++ b/app/controllers/auth_tokens_controller.rb
@@ -34,12 +34,12 @@ class AuthTokensController < ApplicationController
     if @auth_token.save
       render json: transform_auth_token_for_json_with_token(@auth_token), status: :created
     else
-      render json: @auth_token.errors, status: :unprocessable_entity
+      render json: @auth_token.errors, status: :unprocessable_content
     end
   end
 
   def destroy
-    render json: @auth_token.errors, status: :unprocessable_entity unless @auth_token.destroy
+    render json: @auth_token.errors, status: :unprocessable_content unless @auth_token.destroy
   end
 
   private

--- a/app/controllers/codec_conversions_controller.rb
+++ b/app/controllers/codec_conversions_controller.rb
@@ -24,7 +24,7 @@ class CodecConversionsController < ApplicationController
     if @codec_conversion.save
       render json: transform_codec_conversion_for_json(@codec_conversion), status: :created
     else
-      render json: @codec_conversion.errors, status: :unprocessable_entity
+      render json: @codec_conversion.errors, status: :unprocessable_content
     end
   end
 
@@ -32,12 +32,12 @@ class CodecConversionsController < ApplicationController
     if @codec_conversion.update(permitted_attributes(CodecConversion))
       render json: transform_codec_conversion_for_json(@codec_conversion), status: :ok
     else
-      render json: @codec_conversion.errors, status: :unprocessable_entity
+      render json: @codec_conversion.errors, status: :unprocessable_content
     end
   end
 
   def destroy
-    render json: @codec_conversion.errors, status: :unprocessable_entity unless @codec_conversion.destroy
+    render json: @codec_conversion.errors, status: :unprocessable_content unless @codec_conversion.destroy
   end
 
   private

--- a/app/controllers/codecs_controller.rb
+++ b/app/controllers/codecs_controller.rb
@@ -22,7 +22,7 @@ class CodecsController < ApplicationController
     if @codec.save
       render json: transform_codec_for_json(@codec), status: :created
     else
-      render json: @codec.errors, status: :unprocessable_entity
+      render json: @codec.errors, status: :unprocessable_content
     end
   end
 
@@ -30,12 +30,12 @@ class CodecsController < ApplicationController
     if @codec.update(permitted_attributes(@codec))
       render json: transform_codec_for_json(@codec), status: :ok
     else
-      render json: @codec.errors, status: :unprocessable_entity
+      render json: @codec.errors, status: :unprocessable_content
     end
   end
 
   def destroy
-    render json: @codec.errors, status: :unprocessable_entity unless @codec.destroy
+    render json: @codec.errors, status: :unprocessable_content unless @codec.destroy
   end
 
   private

--- a/app/controllers/cover_filenames_controller.rb
+++ b/app/controllers/cover_filenames_controller.rb
@@ -22,12 +22,12 @@ class CoverFilenamesController < ApplicationController
     if @cover_filename.save
       render json: transform_cover_filename_for_json(@cover_filename), status: :created
     else
-      render json: @cover_filename.errors, status: :unprocessable_entity
+      render json: @cover_filename.errors, status: :unprocessable_content
     end
   end
 
   def destroy
-    render json: @cover_filename.errors, status: :unprocessable_entity unless @cover_filename.destroy
+    render json: @cover_filename.errors, status: :unprocessable_content unless @cover_filename.destroy
   end
 
   private

--- a/app/controllers/genres_controller.rb
+++ b/app/controllers/genres_controller.rb
@@ -22,7 +22,7 @@ class GenresController < ApplicationController
     if @genre.save
       render json: transform_genre_for_json(@genre), status: :created
     else
-      render json: @genre.errors, status: :unprocessable_entity
+      render json: @genre.errors, status: :unprocessable_content
     end
   end
 
@@ -30,12 +30,12 @@ class GenresController < ApplicationController
     if @genre.update(permitted_attributes(@genre))
       render json: transform_genre_for_json(@genre), status: :ok
     else
-      render json: @genre.errors, status: :unprocessable_entity
+      render json: @genre.errors, status: :unprocessable_content
     end
   end
 
   def destroy
-    render json: @genre.errors, status: :unprocessable_entity unless @genre.destroy
+    render json: @genre.errors, status: :unprocessable_content unless @genre.destroy
   end
 
   def destroy_empty

--- a/app/controllers/image_types_controller.rb
+++ b/app/controllers/image_types_controller.rb
@@ -22,7 +22,7 @@ class ImageTypesController < ApplicationController
     if @image_type.save
       render json: transform_image_type_for_json(@image_type), status: :created
     else
-      render json: @image_type.errors, status: :unprocessable_entity
+      render json: @image_type.errors, status: :unprocessable_content
     end
   end
 
@@ -30,12 +30,12 @@ class ImageTypesController < ApplicationController
     if @image_type.update(permitted_attributes(@image_type))
       render json: transform_image_type_for_json(@image_type), status: :ok
     else
-      render json: @image_type.errors, status: :unprocessable_entity
+      render json: @image_type.errors, status: :unprocessable_content
     end
   end
 
   def destroy
-    render json: @image_type.errors, status: :unprocessable_entity unless @image_type.destroy
+    render json: @image_type.errors, status: :unprocessable_content unless @image_type.destroy
   end
 
   private

--- a/app/controllers/labels_controller.rb
+++ b/app/controllers/labels_controller.rb
@@ -22,7 +22,7 @@ class LabelsController < ApplicationController
     if @label.save
       render json: transform_label_for_json(@label), status: :created
     else
-      render json: @label.errors, status: :unprocessable_entity
+      render json: @label.errors, status: :unprocessable_content
     end
   end
 
@@ -30,12 +30,12 @@ class LabelsController < ApplicationController
     if @label.update(permitted_attributes(@label))
       render json: transform_label_for_json(@label), status: :ok
     else
-      render json: @label.errors, status: :unprocessable_entity
+      render json: @label.errors, status: :unprocessable_content
     end
   end
 
   def destroy
-    render json: @label.errors, status: :unprocessable_entity unless @label.destroy
+    render json: @label.errors, status: :unprocessable_content unless @label.destroy
   end
 
   def destroy_empty

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -22,12 +22,12 @@ class LocationsController < ApplicationController
     if @location.save
       render json: transform_location_for_json(@location), status: :created
     else
-      render json: @location.errors, status: :unprocessable_entity
+      render json: @location.errors, status: :unprocessable_content
     end
   end
 
   def destroy
-    render json: @location.errors, status: :unprocessable_entity unless @location.destroy
+    render json: @location.errors, status: :unprocessable_content unless @location.destroy
   end
 
   private

--- a/app/controllers/playlists_controller.rb
+++ b/app/controllers/playlists_controller.rb
@@ -23,7 +23,7 @@ class PlaylistsController < ApplicationController
     if @playlist.save
       render json: transform_playlist_for_json(@playlist), status: :created
     else
-      render json: @playlist.errors, status: :unprocessable_entity
+      render json: @playlist.errors, status: :unprocessable_content
     end
   end
 
@@ -31,18 +31,18 @@ class PlaylistsController < ApplicationController
     if @playlist.update(permitted_attributes(@playlist))
       render json: transform_playlist_for_json(@playlist), status: :ok
     else
-      render json: @playlist.errors, status: :unprocessable_entity
+      render json: @playlist.errors, status: :unprocessable_content
     end
   end
 
   def destroy
-    render json: @playlist.errors, status: :unprocessable_entity unless @playlist.destroy
+    render json: @playlist.errors, status: :unprocessable_content unless @playlist.destroy
   end
 
   def add_item
     @item = @playlist.items.create(permitted_attributes(@playlist))
 
-    render json: @item.errors, status: :unprocessable_entity unless @item.save
+    render json: @item.errors, status: :unprocessable_content unless @item.save
   end
 
   private

--- a/app/controllers/plays_controller.rb
+++ b/app/controllers/plays_controller.rb
@@ -20,7 +20,7 @@ class PlaysController < ApplicationController
     if @play.save
       render json: transform_play_for_json(@play), status: :created
     else
-      render json: @play.errors, status: :unprocessable_entity
+      render json: @play.errors, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/tracks_controller.rb
+++ b/app/controllers/tracks_controller.rb
@@ -27,7 +27,7 @@ class TracksController < ApplicationController
     if @track.save
       render json: transform_track_for_json(@track), status: :created
     else
-      render json: @track.errors, status: :unprocessable_entity
+      render json: @track.errors, status: :unprocessable_content
     end
   end
 
@@ -35,12 +35,12 @@ class TracksController < ApplicationController
     if @track.update(transformed_attributes)
       render json: transform_track_for_json(@track), status: :ok
     else
-      render json: @track.errors, status: :unprocessable_entity
+      render json: @track.errors, status: :unprocessable_content
     end
   end
 
   def destroy
-    render json: @track.errors, status: :unprocessable_entity unless @track.destroy
+    render json: @track.errors, status: :unprocessable_content unless @track.destroy
   end
 
   def destroy_empty

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -22,7 +22,7 @@ class UsersController < ApplicationController
     if @user.save
       render json: transform_user_for_json(@user), status: :created
     else
-      render json: @user.errors, status: :unprocessable_entity
+      render json: @user.errors, status: :unprocessable_content
     end
   end
 
@@ -38,12 +38,12 @@ class UsersController < ApplicationController
     if @user.update(permitted_attributes(@user))
       render json: transform_user_for_json(@user), status: :ok
     else
-      render json: @user.errors, status: :unprocessable_entity
+      render json: @user.errors, status: :unprocessable_content
     end
   end
 
   def destroy
-    render json: @user.errors, status: :unprocessable_entity unless @user.destroy
+    render json: @user.errors, status: :unprocessable_content unless @user.destroy
   end
 
   private

--- a/test/controllers/albums_controller_test.rb
+++ b/test/controllers/albums_controller_test.rb
@@ -52,7 +52,7 @@ class AlbumsControllerTest < ActionDispatch::IntegrationTest
       post albums_url, params: { album: { release: album.release } }
     end
 
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
   end
 
   test 'should create dependent album_labels' do
@@ -131,7 +131,7 @@ class AlbumsControllerTest < ActionDispatch::IntegrationTest
     sign_in_as create(:moderator)
     patch album_url(@album), params: { album: { release: @album.release, title: '' } }
 
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
     @album.reload
 
     assert_not_equal '', @album.title

--- a/test/controllers/artists_controller_test.rb
+++ b/test/controllers/artists_controller_test.rb
@@ -47,7 +47,7 @@ class ArtistsControllerTest < ActionDispatch::IntegrationTest
       post artists_url, params: { artist: { name: '' } }
     end
 
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
   end
 
   test 'should show artist' do
@@ -69,7 +69,7 @@ class ArtistsControllerTest < ActionDispatch::IntegrationTest
     sign_in_as create(:moderator)
     patch artist_url(@artist), params: { artist: { name: '' } }
 
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
     @artist.reload
 
     assert_not_equal '', @artist.name

--- a/test/controllers/auth_tokens_controller_test.rb
+++ b/test/controllers/auth_tokens_controller_test.rb
@@ -66,7 +66,7 @@ class AuthTokensControllerTest < ActionDispatch::IntegrationTest
       }
     end
 
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
   end
 
   test 'should show auth_token' do

--- a/test/controllers/codec_conversions_controller_test.rb
+++ b/test/controllers/codec_conversions_controller_test.rb
@@ -68,7 +68,7 @@ class CodecConversionsControllerTest < ActionDispatch::IntegrationTest
       } }
     end
 
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
   end
 
   test 'should not create codec_conversion with empty ffmpeg_params' do
@@ -81,7 +81,7 @@ class CodecConversionsControllerTest < ActionDispatch::IntegrationTest
       } }
     end
 
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
   end
 
   test 'should not create codec_conversion with empty name' do
@@ -94,7 +94,7 @@ class CodecConversionsControllerTest < ActionDispatch::IntegrationTest
       } }
     end
 
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
   end
 
   test 'should not create codec_conversion with non-existing resulting_codec' do
@@ -108,7 +108,7 @@ class CodecConversionsControllerTest < ActionDispatch::IntegrationTest
       } }
     end
 
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
   end
 
   test 'should create codec_conversion for admin' do
@@ -158,7 +158,7 @@ class CodecConversionsControllerTest < ActionDispatch::IntegrationTest
       name: ''
     } }
 
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
   end
 
   test 'should update codec_conversion for admin' do

--- a/test/controllers/codecs_controller_test.rb
+++ b/test/controllers/codecs_controller_test.rb
@@ -28,7 +28,7 @@ class CodecsControllerTest < ActionDispatch::IntegrationTest
       post codecs_url, params: { codec: { mimetype: codec.mimetype } }
     end
 
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
   end
 
   test 'should not create codec with missing mimetype' do
@@ -38,7 +38,7 @@ class CodecsControllerTest < ActionDispatch::IntegrationTest
       post codecs_url, params: { codec: { extension: codec.extension } }
     end
 
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
   end
 
   test 'should create codec for moderator' do
@@ -77,7 +77,7 @@ class CodecsControllerTest < ActionDispatch::IntegrationTest
     sign_in_as(create(:moderator))
     patch codec_url(@codec), params: { codec: { mimetype: '' } }
 
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
   end
 
   test 'should update codec for moderator' do

--- a/test/controllers/cover_filenames_controller_test.rb
+++ b/test/controllers/cover_filenames_controller_test.rb
@@ -41,7 +41,7 @@ class CoverFilenamesControllerTest < ActionDispatch::IntegrationTest
       post cover_filenames_url, params: { cover_filename: { filename: '' } }
     end
 
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
   end
 
   test 'should create cover_filename for moderator' do

--- a/test/controllers/genres_controller_test.rb
+++ b/test/controllers/genres_controller_test.rb
@@ -27,7 +27,7 @@ class GenresControllerTest < ActionDispatch::IntegrationTest
       post genres_url, params: { genre: { name: '' } }
     end
 
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
   end
 
   test 'should create genre for moderator' do
@@ -66,7 +66,7 @@ class GenresControllerTest < ActionDispatch::IntegrationTest
     sign_in_as(create(:moderator))
     patch genre_url(@genre), params: { genre: { name: '' } }
 
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
     @genre.reload
 
     assert_not_equal '', @genre.name

--- a/test/controllers/image_types_controller_test.rb
+++ b/test/controllers/image_types_controller_test.rb
@@ -28,7 +28,7 @@ class ImageTypesControllerTest < ActionDispatch::IntegrationTest
       post image_types_url, params: { image_type: { mimetype: image_type.mimetype } }
     end
 
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
   end
 
   test 'should not create image_type without mimetype' do
@@ -38,7 +38,7 @@ class ImageTypesControllerTest < ActionDispatch::IntegrationTest
       post image_types_url, params: { image_type: { extension: image_type.extension } }
     end
 
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
   end
 
   test 'should create image_type for moderator' do
@@ -77,7 +77,7 @@ class ImageTypesControllerTest < ActionDispatch::IntegrationTest
     sign_in_as(create(:moderator))
     patch image_type_url(@image_type), params: { image_type: { mimetype: '' } }
 
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
     @image_type.reload
 
     assert_not_equal '', @image_type.mimetype

--- a/test/controllers/labels_controller_test.rb
+++ b/test/controllers/labels_controller_test.rb
@@ -28,7 +28,7 @@ class LabelsControllerTest < ActionDispatch::IntegrationTest
       post labels_url, params: { label: { name: '' } }
     end
 
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
   end
 
   test 'should create label for moderator' do
@@ -67,7 +67,7 @@ class LabelsControllerTest < ActionDispatch::IntegrationTest
     sign_in_as(create(:moderator))
     patch label_url(@label), params: { label: { name: '' } }
 
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
     @label.reload
 
     assert_not_equal '', @label.name

--- a/test/controllers/locations_controller_test.rb
+++ b/test/controllers/locations_controller_test.rb
@@ -41,7 +41,7 @@ class LocationsControllerTest < ActionDispatch::IntegrationTest
       post locations_url, params: { location: { path: '' } }
     end
 
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
   end
 
   test 'should create location for moderator' do

--- a/test/controllers/playlists_controller_test.rb
+++ b/test/controllers/playlists_controller_test.rb
@@ -41,7 +41,7 @@ class PlaylistsControllerTest < ActionDispatch::IntegrationTest
       post playlists_url, params: { playlist: { name: '', playlist_type: :track } }
     end
 
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
   end
 
   test 'should create personal playlist for current user if specified' do
@@ -75,7 +75,7 @@ class PlaylistsControllerTest < ActionDispatch::IntegrationTest
   test 'should not update playlist with empty name' do
     patch playlist_url(@playlist), params: { playlist: { name: '' } }
 
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
   end
 
   test 'should create playlist items during update' do

--- a/test/controllers/plays_controller_test.rb
+++ b/test/controllers/plays_controller_test.rb
@@ -43,7 +43,7 @@ class PlaysControllerTest < ActionDispatch::IntegrationTest
       post plays_url, params: { play: { played_at: nil, track_id: @track.id } }
     end
 
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
   end
 
   test 'should get stats and  not return play stats for other users' do

--- a/test/controllers/tracks_controller_test.rb
+++ b/test/controllers/tracks_controller_test.rb
@@ -51,7 +51,7 @@ class TracksControllerTest < ActionDispatch::IntegrationTest
       post tracks_url, params: { track: { album_id: @track.album_id, number: @track.number + 1 } }
     end
 
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
   end
 
   test 'should not create track without album_id' do
@@ -60,7 +60,7 @@ class TracksControllerTest < ActionDispatch::IntegrationTest
       post tracks_url, params: { track: { number: @track.number + 1, title: 'Title' } }
     end
 
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
   end
 
   test 'should create track for moderator' do
@@ -135,7 +135,7 @@ class TracksControllerTest < ActionDispatch::IntegrationTest
     sign_in_as(create(:moderator))
     patch track_url(@track), params: { track: { title: '' } }
 
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
     @track.reload
 
     assert_not_equal '', @track.title

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -28,7 +28,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
       post users_url, params: { user: { password: 'password', permission: user.permission } }
     end
 
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
   end
 
   test 'should create user for admin' do
@@ -76,7 +76,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     sign_in_as(create(:admin))
     patch user_url(@user), params: { user: { name: '' } }
 
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
     @user.reload
 
     assert_not_equal '', @user.name


### PR DESCRIPTION
The status `unprocessable_entity` is deprecated (and not actual name of the 422 response) and will be removed in a future version of rack ([rack](https://github.com/rack/rack/blob/fac9a7a6cf01be691245947dab9fc9d3861230e1/lib/rack/utils.rb#L570), [mdn](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/422)).

- [ ] I've added tests relevant to my changes.

<!---
  If you did any manual testing as well, please mention so
  here. Provide instructions so we can reproduce those tests.
  --->
