### PR TITLE
Add custom logic for etags to all index actions

### DIFF
--- a/app/controllers/albums_controller.rb
+++ b/app/controllers/albums_controller.rb
@@ -10,12 +10,12 @@ class AlbumsController < ApplicationController
 
   def index
     authorize Album
-    @albums = apply_scopes(policy_scope(Album))
-              .includes(:album_artists, :album_labels, image: [{ image_attachment: :blob }, :image_type])
-              .paginate(page: params[:page], per_page: params[:per_page])
+    scoped_albums = apply_scopes(policy_scope(Album))
+    @albums = scoped_albums.includes(:album_artists, :album_labels, image: [{ image_attachment: :blob }, :image_type])
+                           .paginate(page: params[:page], per_page: params[:per_page])
     add_pagination_headers(@albums)
 
-    render json: @albums.map { transform_album_for_json(it) }
+    render json: @albums.map { transform_album_for_json(it) } if stale?(etag: scoped_albums)
   end
 
   def show

--- a/app/controllers/albums_controller.rb
+++ b/app/controllers/albums_controller.rb
@@ -15,7 +15,7 @@ class AlbumsController < ApplicationController
                            .paginate(page: params[:page], per_page: params[:per_page])
     add_pagination_headers(@albums)
 
-    render json: @albums.map { transform_album_for_json(it) } if stale?(etag: scoped_albums)
+    render json: @albums.map { transform_album_for_json(it) } if stale?(scope: scoped_albums)
   end
 
   def show

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,9 @@ class ApplicationController < ActionController::API
   include Pundit::Authorization
   include ActionController::HttpAuthentication::Token::ControllerMethods
 
+  etag { params[:page] }
+  etag { params[:per_page] }
+
   attr_accessor :current_user
 
   before_action :authenticate_user

--- a/app/controllers/artists_controller.rb
+++ b/app/controllers/artists_controller.rb
@@ -7,12 +7,12 @@ class ArtistsController < ApplicationController
 
   def index
     authorize Artist
-    @artists = apply_scopes(policy_scope(Artist))
-               .includes(image: [{ image_attachment: :blob }, :image_type])
-               .paginate(page: params[:page], per_page: params[:per_page])
+    scoped_artists = apply_scopes(policy_scope(Artist))
+    @artists = scoped_artists.includes(image: [{ image_attachment: :blob }, :image_type])
+                             .paginate(page: params[:page], per_page: params[:per_page])
     add_pagination_headers(@artists)
 
-    render json: @artists.map { transform_artist_for_json(it) }
+    render json: @artists.map { transform_artist_for_json(it) } if stale?(etag: scoped_artists)
   end
 
   def show

--- a/app/controllers/artists_controller.rb
+++ b/app/controllers/artists_controller.rb
@@ -12,7 +12,7 @@ class ArtistsController < ApplicationController
                              .paginate(page: params[:page], per_page: params[:per_page])
     add_pagination_headers(@artists)
 
-    render json: @artists.map { transform_artist_for_json(it) } if stale?(etag: scoped_artists)
+    render json: @artists.map { transform_artist_for_json(it) } if stale?(scope: scoped_artists)
   end
 
   def show

--- a/app/controllers/auth_tokens_controller.rb
+++ b/app/controllers/auth_tokens_controller.rb
@@ -3,12 +3,11 @@ class AuthTokensController < ApplicationController
 
   def index
     authorize AuthToken
-    @auth_tokens = apply_scopes(policy_scope(AuthToken))
-                   .order(id: :asc)
-                   .paginate(page: params[:page], per_page: params[:per_page])
+    scoped_tokens = apply_scopes(policy_scope(AuthToken)).reorder(id: :asc)
+    @auth_tokens = scoped_tokens.paginate(page: params[:page], per_page: params[:per_page])
     add_pagination_headers(@auth_tokens)
 
-    render json: @auth_tokens.map { transform_auth_token_for_json(it) }
+    render json: @auth_tokens.map { transform_auth_token_for_json(it) } if stale?(scope: scoped_tokens)
   end
 
   def show

--- a/app/controllers/codec_conversions_controller.rb
+++ b/app/controllers/codec_conversions_controller.rb
@@ -5,12 +5,11 @@ class CodecConversionsController < ApplicationController
 
   def index
     authorize CodecConversion
-    @codec_conversions = apply_scopes(policy_scope(CodecConversion))
-                         .order(id: :asc)
-                         .paginate(page: params[:page], per_page: params[:per_page])
+    scoped_conversions = apply_scopes(policy_scope(CodecConversion)).reorder(id: :asc)
+    @codec_conversions = scoped_conversions.paginate(page: params[:page], per_page: params[:per_page])
     add_pagination_headers(@codec_conversions)
 
-    render json: @codec_conversions.map { transform_codec_conversion_for_json(it) }
+    render json: @codec_conversions.map { transform_codec_conversion_for_json(it) } if stale?(scope: scoped_conversions)
   end
 
   def show

--- a/app/controllers/codecs_controller.rb
+++ b/app/controllers/codecs_controller.rb
@@ -3,12 +3,11 @@ class CodecsController < ApplicationController
 
   def index
     authorize Codec
-    @codecs = apply_scopes(policy_scope(Codec))
-              .order(id: :asc)
-              .paginate(page: params[:page], per_page: params[:per_page])
+    scoped_codecs = apply_scopes(policy_scope(Codec)).reorder(id: :asc)
+    @codecs = scoped_codecs.paginate(page: params[:page], per_page: params[:per_page])
     add_pagination_headers(@codecs)
 
-    render json: @codecs.map { transform_codec_for_json(it) }
+    render json: @codecs.map { transform_codec_for_json(it) } if stale?(scope: scoped_codecs)
   end
 
   def show

--- a/app/controllers/cover_filenames_controller.rb
+++ b/app/controllers/cover_filenames_controller.rb
@@ -3,12 +3,11 @@ class CoverFilenamesController < ApplicationController
 
   def index
     authorize CoverFilename
-    @cover_filenames = apply_scopes(policy_scope(CoverFilename))
-                       .order(id: :asc)
-                       .paginate(page: params[:page], per_page: params[:per_page])
+    scoped_filenames = apply_scopes(policy_scope(CoverFilename)).reorder(id: :asc)
+    @cover_filenames = scoped_filenames.paginate(page: params[:page], per_page: params[:per_page])
     add_pagination_headers(@cover_filenames)
 
-    render json: @cover_filenames.map { transform_cover_filename_for_json(it) }
+    render json: @cover_filenames.map { transform_cover_filename_for_json(it) } if stale?(scope: scoped_filenames)
   end
 
   def show

--- a/app/controllers/genres_controller.rb
+++ b/app/controllers/genres_controller.rb
@@ -3,12 +3,11 @@ class GenresController < ApplicationController
 
   def index
     authorize Genre
-    scoped_genres = apply_scopes(policy_scope(Genre))
-    @genres = scoped_genres.order(id: :asc)
-                           .paginate(page: params[:page], per_page: params[:per_page])
+    scoped_genres = apply_scopes(policy_scope(Genre)).reorder(id: :asc)
+    @genres = scoped_genres.paginate(page: params[:page], per_page: params[:per_page])
     add_pagination_headers(@genres)
 
-    render json: @genres.map { transform_genre_for_json(it) } if stale?(etag: scoped_genres)
+    render json: @genres.map { transform_genre_for_json(it) } if stale?(scope: scoped_genres)
   end
 
   def show

--- a/app/controllers/genres_controller.rb
+++ b/app/controllers/genres_controller.rb
@@ -3,12 +3,12 @@ class GenresController < ApplicationController
 
   def index
     authorize Genre
-    @genres = apply_scopes(policy_scope(Genre))
-              .order(id: :asc)
-              .paginate(page: params[:page], per_page: params[:per_page])
+    scoped_genres = apply_scopes(policy_scope(Genre))
+    @genres = scoped_genres.order(id: :asc)
+                           .paginate(page: params[:page], per_page: params[:per_page])
     add_pagination_headers(@genres)
 
-    render json: @genres.map { transform_genre_for_json(it) }
+    render json: @genres.map { transform_genre_for_json(it) } if stale?(etag: scoped_genres)
   end
 
   def show

--- a/app/controllers/image_types_controller.rb
+++ b/app/controllers/image_types_controller.rb
@@ -3,12 +3,11 @@ class ImageTypesController < ApplicationController
 
   def index
     authorize ImageType
-    @image_types = apply_scopes(policy_scope(ImageType))
-                   .order(id: :asc)
-                   .paginate(page: params[:page], per_page: params[:per_page])
+    scoped_types = apply_scopes(policy_scope(ImageType)).reorder(id: :asc)
+    @image_types = scoped_types.paginate(page: params[:page], per_page: params[:per_page])
     add_pagination_headers(@image_types)
 
-    render json: @image_types.map { transform_image_type_for_json(it) }
+    render json: @image_types.map { transform_image_type_for_json(it) } if stale?(scope: scoped_types)
   end
 
   def show

--- a/app/controllers/labels_controller.rb
+++ b/app/controllers/labels_controller.rb
@@ -3,12 +3,12 @@ class LabelsController < ApplicationController
 
   def index
     authorize Label
-    @labels = apply_scopes(policy_scope(Label))
-              .order(id: :asc)
-              .paginate(page: params[:page], per_page: params[:per_page])
+    scoped_labels = apply_scopes(policy_scope(Label))
+    @labels = scoped_labels.order(id: :asc)
+                           .paginate(page: params[:page], per_page: params[:per_page])
     add_pagination_headers(@labels)
 
-    render json: @labels.map { transform_label_for_json(it) }
+    render json: @labels.map { transform_label_for_json(it) } if stale?(etag: scoped_labels)
   end
 
   def show

--- a/app/controllers/labels_controller.rb
+++ b/app/controllers/labels_controller.rb
@@ -3,12 +3,11 @@ class LabelsController < ApplicationController
 
   def index
     authorize Label
-    scoped_labels = apply_scopes(policy_scope(Label))
-    @labels = scoped_labels.order(id: :asc)
-                           .paginate(page: params[:page], per_page: params[:per_page])
+    scoped_labels = apply_scopes(policy_scope(Label)).reorder(id: :asc)
+    @labels = scoped_labels.paginate(page: params[:page], per_page: params[:per_page])
     add_pagination_headers(@labels)
 
-    render json: @labels.map { transform_label_for_json(it) } if stale?(etag: scoped_labels)
+    render json: @labels.map { transform_label_for_json(it) } if stale?(scope: scoped_labels)
   end
 
   def show

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -3,12 +3,11 @@ class LocationsController < ApplicationController
 
   def index
     authorize Location
-    @locations = apply_scopes(policy_scope(Location))
-                 .order(id: :asc)
-                 .paginate(page: params[:page], per_page: params[:per_page])
+    scoped_locations = apply_scopes(policy_scope(Location)).reorder(id: :asc)
+    @locations = scoped_locations.paginate(page: params[:page], per_page: params[:per_page])
     add_pagination_headers(@locations)
 
-    render json: @locations.map { transform_location_for_json(it) }
+    render json: @locations.map { transform_location_for_json(it) } if stale?(scope: scoped_locations)
   end
 
   def show

--- a/app/controllers/playlists_controller.rb
+++ b/app/controllers/playlists_controller.rb
@@ -3,11 +3,11 @@ class PlaylistsController < ApplicationController
 
   def index
     authorize Playlist
-    scoped_playlists = apply_scopes(policy_scope(Playlist)).with_item_ids.order(id: :asc)
+    scoped_playlists = apply_scopes(policy_scope(Playlist)).with_item_ids.reorder(id: :asc)
     @playlists = scoped_playlists.paginate(page: params[:page], per_page: params[:per_page])
     add_pagination_headers(@playlists)
 
-    render json: @playlists.map { transform_playlist_for_json(it) } if stale?(etag: scoped_playlists)
+    render json: @playlists.map { transform_playlist_for_json(it) } if stale?(scope: scoped_playlists)
   end
 
   def show

--- a/app/controllers/playlists_controller.rb
+++ b/app/controllers/playlists_controller.rb
@@ -3,13 +3,11 @@ class PlaylistsController < ApplicationController
 
   def index
     authorize Playlist
-    @playlists = apply_scopes(policy_scope(Playlist))
-                 .with_item_ids
-                 .order(id: :asc)
-                 .paginate(page: params[:page], per_page: params[:per_page])
+    scoped_playlists = apply_scopes(policy_scope(Playlist)).with_item_ids.order(id: :asc)
+    @playlists = scoped_playlists.paginate(page: params[:page], per_page: params[:per_page])
     add_pagination_headers(@playlists)
 
-    render json: @playlists.map { transform_playlist_for_json(it) }
+    render json: @playlists.map { transform_playlist_for_json(it) } if stale?(etag: scoped_playlists)
   end
 
   def show

--- a/app/controllers/plays_controller.rb
+++ b/app/controllers/plays_controller.rb
@@ -6,11 +6,11 @@ class PlaysController < ApplicationController
 
   def index
     authorize Play
-    @plays = apply_scopes(policy_scope(Play))
-             .paginate(page: params[:page], per_page: params[:per_page])
+    scoped_plays = apply_scopes(policy_scope(Play))
+    @plays = scoped_plays.paginate(page: params[:page], per_page: params[:per_page])
     add_pagination_headers(@plays)
 
-    render json: @plays.map { transform_play_for_json(it) }
+    render json: @plays.map { transform_play_for_json(it) } if stale?(etag: scoped_plays)
   end
 
   def create

--- a/app/controllers/plays_controller.rb
+++ b/app/controllers/plays_controller.rb
@@ -10,7 +10,7 @@ class PlaysController < ApplicationController
     @plays = scoped_plays.paginate(page: params[:page], per_page: params[:per_page])
     add_pagination_headers(@plays)
 
-    render json: @plays.map { transform_play_for_json(it) } if stale?(etag: scoped_plays)
+    render json: @plays.map { transform_play_for_json(it) } if stale?(scope: scoped_plays)
   end
 
   def create

--- a/app/controllers/rescans_controller.rb
+++ b/app/controllers/rescans_controller.rb
@@ -3,10 +3,11 @@ class RescansController < ApplicationController
 
   def index
     authorize RescanRunner
-    @rescans = policy_scope(RescanRunner).paginate(page: params[:page], per_page: params[:per_page])
+    scoped_rescans = policy_scope(RescanRunner)
+    @rescans = scoped_rescans.paginate(page: params[:page], per_page: params[:per_page])
     add_pagination_headers(@rescans)
 
-    render json: @rescans.map { transform_rescan_runner_for_json(it) }
+    render json: @rescans.map { transform_rescan_runner_for_json(it) } if stale?(scope: scoped_rescans)
   end
 
   def show

--- a/app/controllers/tracks_controller.rb
+++ b/app/controllers/tracks_controller.rb
@@ -8,12 +8,11 @@ class TracksController < ApplicationController
 
   def index
     authorize Track
-    scoped_tracks = apply_scopes(policy_scope(Track))
-    @tracks = scoped_tracks.includes(:track_artists, :genres, audio_file: %i[location codec])
-                           .paginate(page: params[:page], per_page: params[:per_page])
+    scoped_tracks = apply_scopes(policy_scope(Track)).includes(:track_artists, :genres, audio_file: %i[location codec])
+    @tracks = scoped_tracks.paginate(page: params[:page], per_page: params[:per_page])
     add_pagination_headers(@tracks)
 
-    render json: @tracks.map { transform_track_for_json(it) } if stale?(etag: scoped_tracks)
+    render json: @tracks.map { transform_track_for_json(it) } if stale?(scope: scoped_tracks)
   end
 
   def show

--- a/app/controllers/tracks_controller.rb
+++ b/app/controllers/tracks_controller.rb
@@ -8,12 +8,12 @@ class TracksController < ApplicationController
 
   def index
     authorize Track
-    @tracks = apply_scopes(policy_scope(Track))
-              .includes(:track_artists, :genres, audio_file: %i[location codec])
-              .paginate(page: params[:page], per_page: params[:per_page])
+    scoped_tracks = apply_scopes(policy_scope(Track))
+    @tracks = scoped_tracks.includes(:track_artists, :genres, audio_file: %i[location codec])
+                           .paginate(page: params[:page], per_page: params[:per_page])
     add_pagination_headers(@tracks)
 
-    render json: @tracks.map { transform_track_for_json(it) }
+    render json: @tracks.map { transform_track_for_json(it) } if stale?(etag: scoped_tracks)
   end
 
   def show

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,12 +3,11 @@ class UsersController < ApplicationController
 
   def index
     authorize User
-    @users = apply_scopes(policy_scope(User))
-             .order(id: :asc)
-             .paginate(page: params[:page], per_page: params[:per_page])
+    scoped_users = apply_scopes(policy_scope(User)).reorder(id: :asc)
+    @users = scoped_users.paginate(page: params[:page], per_page: params[:per_page])
     add_pagination_headers(@users)
 
-    render json: @users.map { transform_user_for_json(it) }
+    render json: @users.map { transform_user_for_json(it) } if stale?(scope: scoped_users)
   end
 
   def show

--- a/app/models/album.rb
+++ b/app/models/album.rb
@@ -17,6 +17,7 @@
 #
 #  index_albums_on_image_id          (image_id) UNIQUE
 #  index_albums_on_normalized_title  (normalized_title)
+#  index_albums_on_updated_at        (updated_at)
 #
 # Foreign Keys
 #

--- a/app/models/album_artist.rb
+++ b/app/models/album_artist.rb
@@ -28,7 +28,7 @@
 class AlbumArtist < ApplicationRecord
   include HasNormalized
 
-  belongs_to :album
+  belongs_to :album, touch: true
   belongs_to :artist
 
   validates :name, presence: true

--- a/app/models/album_label.rb
+++ b/app/models/album_label.rb
@@ -22,7 +22,7 @@
 #
 
 class AlbumLabel < ApplicationRecord
-  belongs_to :album
+  belongs_to :album, touch: true
   belongs_to :label
 
   validates :album, uniqueness: { scope: :label }

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -14,6 +14,7 @@
 #
 #  index_artists_on_image_id         (image_id) UNIQUE
 #  index_artists_on_normalized_name  (normalized_name)
+#  index_artists_on_updated_at       (updated_at)
 #
 # Foreign Keys
 #

--- a/app/models/play.rb
+++ b/app/models/play.rb
@@ -11,9 +11,10 @@
 #
 # Indexes
 #
-#  index_plays_on_track_id              (track_id)
-#  index_plays_on_user_id               (user_id)
-#  index_plays_on_user_id_and_track_id  (user_id,track_id)
+#  index_plays_on_track_id                (track_id)
+#  index_plays_on_user_id                 (user_id)
+#  index_plays_on_user_id_and_track_id    (user_id,track_id)
+#  index_plays_on_user_id_and_updated_at  (user_id,updated_at)
 #
 # Foreign Keys
 #

--- a/app/models/playlist_item.rb
+++ b/app/models/playlist_item.rb
@@ -20,7 +20,7 @@
 #  fk_rails_...  (playlist_id => playlists.id)
 #
 class PlaylistItem < ApplicationRecord
-  belongs_to :playlist
+  belongs_to :playlist, touch: true
   belongs_to :item, polymorphic: true
 
   validates :order, presence: true

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -17,6 +17,7 @@
 #  index_tracks_on_album_id          (album_id)
 #  index_tracks_on_audio_file_id     (audio_file_id) UNIQUE
 #  index_tracks_on_normalized_title  (normalized_title)
+#  index_tracks_on_updated_at        (updated_at)
 #
 # Foreign Keys
 #

--- a/app/models/track_artist.rb
+++ b/app/models/track_artist.rb
@@ -31,7 +31,7 @@ class TrackArtist < ApplicationRecord
 
   enum :role, { main: 0, performer: 1, composer: 2, conductor: 3, remixer: 4, producer: 5, arranger: 6 }
 
-  belongs_to :track
+  belongs_to :track, touch: true
   belongs_to :artist
 
   validates :role, presence: true

--- a/db/migrate/20250914144855_add_index_updated_at.rb
+++ b/db/migrate/20250914144855_add_index_updated_at.rb
@@ -1,0 +1,8 @@
+class AddIndexUpdatedAt < ActiveRecord::Migration[8.0]
+  def change
+    add_index :albums, :updated_at
+    add_index :artists, :updated_at
+    add_index :plays, [:user_id, :updated_at]
+    add_index :tracks, :updated_at
+  end
+end

--- a/db/migrate/20250914144855_add_index_updated_at.rb
+++ b/db/migrate/20250914144855_add_index_updated_at.rb
@@ -1,8 +1,10 @@
 class AddIndexUpdatedAt < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
   def change
-    add_index :albums, :updated_at
-    add_index :artists, :updated_at
-    add_index :plays, [:user_id, :updated_at]
-    add_index :tracks, :updated_at
+    add_index :albums, :updated_at, algorithm: :concurrently
+    add_index :artists, :updated_at, algorithm: :concurrently
+    add_index :plays, [:user_id, :updated_at], algorithm: :concurrently
+    add_index :tracks, :updated_at, algorithm: :concurrently
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_14_101209) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_14_144855) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -80,6 +80,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_14_101209) do
     t.string "normalized_title", null: false
     t.index ["image_id"], name: "index_albums_on_image_id", unique: true
     t.index ["normalized_title"], name: "index_albums_on_normalized_title"
+    t.index ["updated_at"], name: "index_albums_on_updated_at"
   end
 
   create_table "artists", force: :cascade do |t|
@@ -91,6 +92,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_14_101209) do
     t.string "normalized_name", null: false
     t.index ["image_id"], name: "index_artists_on_image_id", unique: true
     t.index ["normalized_name"], name: "index_artists_on_normalized_name"
+    t.index ["updated_at"], name: "index_artists_on_updated_at"
   end
 
   create_table "audio_files", force: :cascade do |t|
@@ -311,6 +313,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_14_101209) do
     t.datetime "updated_at", null: false
     t.index ["track_id"], name: "index_plays_on_track_id"
     t.index ["user_id", "track_id"], name: "index_plays_on_user_id_and_track_id"
+    t.index ["user_id", "updated_at"], name: "index_plays_on_user_id_and_updated_at"
     t.index ["user_id"], name: "index_plays_on_user_id"
   end
 
@@ -354,6 +357,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_14_101209) do
     t.index ["album_id"], name: "index_tracks_on_album_id"
     t.index ["audio_file_id"], name: "index_tracks_on_audio_file_id", unique: true
     t.index ["normalized_title"], name: "index_tracks_on_normalized_title"
+    t.index ["updated_at"], name: "index_tracks_on_updated_at"
   end
 
   create_table "transcoded_items", force: :cascade do |t|

--- a/test/controllers/albums_controller_test.rb
+++ b/test/controllers/albums_controller_test.rb
@@ -7,7 +7,7 @@ class AlbumsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should get index' do
-    expected_etag = "W/\"#{ActiveSupport::Digest.hexdigest(Album.order(id: :desc).cache_key_with_version)}\""
+    expected_etag = construct_etag(Album.order(id: :desc))
 
     get albums_url
 
@@ -16,7 +16,7 @@ class AlbumsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should get index and return not modified if etag matches' do
-    expected_etag = "W/\"#{ActiveSupport::Digest.hexdigest(Album.order(id: :desc).cache_key_with_version)}\""
+    expected_etag = construct_etag(Album.order(id: :desc))
 
     get albums_url, headers: { 'If-None-Match': expected_etag }
 
@@ -25,7 +25,7 @@ class AlbumsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should get index and include page in etag' do
-    expected_etag = "W/\"#{ActiveSupport::Digest.hexdigest(ActiveSupport::Cache.expand_cache_key([Album.order(id: :desc).cache_key_with_version, 5, 501]))}\""
+    expected_etag = construct_etag(Album.order(id: :desc), page: 5, per_page: 501)
 
     get albums_url(page: 5, per_page: 501)
 

--- a/test/controllers/albums_controller_test.rb
+++ b/test/controllers/albums_controller_test.rb
@@ -7,9 +7,30 @@ class AlbumsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should get index' do
+    expected_etag = "W/\"#{ActiveSupport::Digest.hexdigest(Album.order(id: :desc).cache_key_with_version)}\""
+
     get albums_url
 
     assert_response :success
+    assert_equal expected_etag, headers['etag']
+  end
+
+  test 'should get index and return not modified if etag matches' do
+    expected_etag = "W/\"#{ActiveSupport::Digest.hexdigest(Album.order(id: :desc).cache_key_with_version)}\""
+
+    get albums_url, headers: { 'If-None-Match': expected_etag }
+
+    assert_response :not_modified
+    assert_empty response.parsed_body
+  end
+
+  test 'should get index and include page in etag' do
+    expected_etag = "W/\"#{ActiveSupport::Digest.hexdigest(ActiveSupport::Cache.expand_cache_key([Album.order(id: :desc).cache_key_with_version, 5, 501]))}\""
+
+    get albums_url(page: 5, per_page: 501)
+
+    assert_response :success
+    assert_equal expected_etag, headers['etag']
   end
 
   test 'should not create album for user' do

--- a/test/controllers/artists_controller_test.rb
+++ b/test/controllers/artists_controller_test.rb
@@ -7,9 +7,30 @@ class ArtistsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should get index' do
+    expected_etag = construct_etag(Artist.order(id: :desc))
+
     get artists_url
 
     assert_response :success
+    assert_equal expected_etag, headers['etag']
+  end
+
+  test 'should get index and return not modified if etag matches' do
+    expected_etag = construct_etag(Artist.order(id: :desc))
+
+    get artists_url, headers: { 'If-None-Match': expected_etag }
+
+    assert_response :not_modified
+    assert_empty response.parsed_body
+  end
+
+  test 'should get index and include page in etag' do
+    expected_etag = construct_etag(Artist.order(id: :desc), page: 5, per_page: 501)
+
+    get artists_url(page: 5, per_page: 501)
+
+    assert_response :success
+    assert_equal expected_etag, headers['etag']
   end
 
   test 'should not create artist for user' do

--- a/test/controllers/codec_conversions_controller_test.rb
+++ b/test/controllers/codec_conversions_controller_test.rb
@@ -7,9 +7,30 @@ class CodecConversionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should get index' do
+    expected_etag = construct_etag(CodecConversion.order(id: :asc))
+
     get codec_conversions_url
 
     assert_response :success
+    assert_equal expected_etag, headers['etag']
+  end
+
+  test 'should get index and return not modified if etag matches' do
+    expected_etag = construct_etag(CodecConversion.order(id: :asc))
+
+    get codec_conversions_url, headers: { 'If-None-Match': expected_etag }
+
+    assert_response :not_modified
+    assert_empty response.parsed_body
+  end
+
+  test 'should get index and include page in etag' do
+    expected_etag = construct_etag(CodecConversion.order(id: :asc), page: 5, per_page: 501)
+
+    get codec_conversions_url(page: 5, per_page: 501)
+
+    assert_response :success
+    assert_equal expected_etag, headers['etag']
   end
 
   test 'should filter by codec' do

--- a/test/controllers/codecs_controller_test.rb
+++ b/test/controllers/codecs_controller_test.rb
@@ -7,9 +7,30 @@ class CodecsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should get index' do
+    expected_etag = construct_etag(Codec.order(id: :asc))
+
     get codecs_url
 
     assert_response :success
+    assert_equal expected_etag, headers['etag']
+  end
+
+  test 'should get index and return not modified if etag matches' do
+    expected_etag = construct_etag(Codec.order(id: :asc))
+
+    get codecs_url, headers: { 'If-None-Match': expected_etag }
+
+    assert_response :not_modified
+    assert_empty response.parsed_body
+  end
+
+  test 'should get index and include page in etag' do
+    expected_etag = construct_etag(Codec.order(id: :asc), page: 5, per_page: 501)
+
+    get codecs_url(page: 5, per_page: 501)
+
+    assert_response :success
+    assert_equal expected_etag, headers['etag']
   end
 
   test 'should not create codec for user' do

--- a/test/controllers/cover_filenames_controller_test.rb
+++ b/test/controllers/cover_filenames_controller_test.rb
@@ -14,16 +14,42 @@ class CoverFilenamesControllerTest < ActionDispatch::IntegrationTest
 
   test 'should get index for moderator' do
     sign_in_as create(:moderator)
+    expected_etag = construct_etag(CoverFilename.order(id: :asc))
+
     get cover_filenames_url
 
     assert_response :success
+    assert_equal expected_etag, headers['etag']
   end
 
   test 'should get index for admin' do
     sign_in_as create(:admin)
+    expected_etag = construct_etag(CoverFilename.order(id: :asc))
+
     get cover_filenames_url
 
     assert_response :success
+    assert_equal expected_etag, headers['etag']
+  end
+
+  test 'should get index and return not modified if etag matches' do
+    sign_in_as create(:admin)
+    expected_etag = construct_etag(CoverFilename.order(id: :asc))
+
+    get cover_filenames_url, headers: { 'If-None-Match': expected_etag }
+
+    assert_response :not_modified
+    assert_empty response.parsed_body
+  end
+
+  test 'should get index and include page in etag' do
+    sign_in_as create(:admin)
+    expected_etag = construct_etag(CoverFilename.order(id: :asc), page: 5, per_page: 501)
+
+    get cover_filenames_url(page: 5, per_page: 501)
+
+    assert_response :success
+    assert_equal expected_etag, headers['etag']
   end
 
   test 'should not create cover_filename for user' do

--- a/test/controllers/genres_controller_test.rb
+++ b/test/controllers/genres_controller_test.rb
@@ -7,9 +7,30 @@ class GenresControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should get index' do
+    expected_etag = construct_etag(Genre.order(id: :asc))
+
     get genres_url
 
     assert_response :success
+    assert_equal expected_etag, headers['etag']
+  end
+
+  test 'should get index and return not modified if etag matches' do
+    expected_etag = construct_etag(Genre.order(id: :asc))
+
+    get genres_url, headers: { 'If-None-Match': expected_etag }
+
+    assert_response :not_modified
+    assert_empty response.parsed_body
+  end
+
+  test 'should get index and include page in etag' do
+    expected_etag = construct_etag(Genre.order(id: :asc), page: 5, per_page: 501)
+
+    get genres_url(page: 5, per_page: 501)
+
+    assert_response :success
+    assert_equal expected_etag, headers['etag']
   end
 
   test 'should not create genre for user' do

--- a/test/controllers/image_types_controller_test.rb
+++ b/test/controllers/image_types_controller_test.rb
@@ -7,9 +7,30 @@ class ImageTypesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should get index' do
+    expected_etag = construct_etag(ImageType.order(id: :asc))
+
     get image_types_url
 
     assert_response :success
+    assert_equal expected_etag, headers['etag']
+  end
+
+  test 'should get index and return not modified if etag matches' do
+    expected_etag = construct_etag(ImageType.order(id: :asc))
+
+    get image_types_url, headers: { 'If-None-Match': expected_etag }
+
+    assert_response :not_modified
+    assert_empty response.parsed_body
+  end
+
+  test 'should get index and include page in etag' do
+    expected_etag = construct_etag(ImageType.order(id: :asc), page: 5, per_page: 501)
+
+    get image_types_url(page: 5, per_page: 501)
+
+    assert_response :success
+    assert_equal expected_etag, headers['etag']
   end
 
   test 'should not create image_type for user' do

--- a/test/controllers/labels_controller_test.rb
+++ b/test/controllers/labels_controller_test.rb
@@ -7,9 +7,30 @@ class LabelsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should get index' do
+    expected_etag = construct_etag(Label.order(id: :asc))
+
     get labels_url
 
     assert_response :success
+    assert_equal expected_etag, headers['etag']
+  end
+
+  test 'should get index and return not modified if etag matches' do
+    expected_etag = construct_etag(Label.order(id: :asc))
+
+    get labels_url, headers: { 'If-None-Match': expected_etag }
+
+    assert_response :not_modified
+    assert_empty response.parsed_body
+  end
+
+  test 'should get index and include page in etag' do
+    expected_etag = construct_etag(Label.order(id: :asc), page: 5, per_page: 501)
+
+    get labels_url(page: 5, per_page: 501)
+
+    assert_response :success
+    assert_equal expected_etag, headers['etag']
   end
 
   test 'should not create label for user' do

--- a/test/controllers/locations_controller_test.rb
+++ b/test/controllers/locations_controller_test.rb
@@ -14,16 +14,42 @@ class LocationsControllerTest < ActionDispatch::IntegrationTest
 
   test 'should get index for moderator' do
     sign_in_as create(:moderator)
+    expected_etag = construct_etag(Location.order(id: :asc))
+
     get locations_url
 
     assert_response :success
+    assert_equal expected_etag, headers['etag']
   end
 
   test 'should get index for admin' do
     sign_in_as create(:admin)
+    expected_etag = construct_etag(Location.order(id: :asc))
+
     get locations_url
 
     assert_response :success
+    assert_equal expected_etag, headers['etag']
+  end
+
+  test 'should get index and return not modified if etag matches' do
+    sign_in_as create(:admin)
+    expected_etag = construct_etag(Location.order(id: :asc))
+
+    get locations_url, headers: { 'If-None-Match': expected_etag }
+
+    assert_response :not_modified
+    assert_empty response.parsed_body
+  end
+
+  test 'should get index and include page in etag' do
+    sign_in_as create(:admin)
+    expected_etag = construct_etag(Location.order(id: :asc), page: 5, per_page: 501)
+
+    get locations_url(page: 5, per_page: 501)
+
+    assert_response :success
+    assert_equal expected_etag, headers['etag']
   end
 
   test 'should not create location for user' do

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -7,9 +7,30 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should get index' do
+    expected_etag = construct_etag(User.order(id: :asc))
+
     get users_url
 
     assert_response :success
+    assert_equal expected_etag, headers['etag']
+  end
+
+  test 'should get index and return not modified if etag matches' do
+    expected_etag = construct_etag(User.order(id: :asc))
+
+    get users_url, headers: { 'If-None-Match': expected_etag }
+
+    assert_response :not_modified
+    assert_empty response.parsed_body
+  end
+
+  test 'should get index and include page in etag' do
+    expected_etag = construct_etag(User.order(id: :asc), page: 5, per_page: 501)
+
+    get users_url(page: 5, per_page: 501)
+
+    assert_response :success
+    assert_equal expected_etag, headers['etag']
   end
 
   test 'should not create user for user' do

--- a/test/factories/albums.rb
+++ b/test/factories/albums.rb
@@ -17,6 +17,7 @@
 #
 #  index_albums_on_image_id          (image_id) UNIQUE
 #  index_albums_on_normalized_title  (normalized_title)
+#  index_albums_on_updated_at        (updated_at)
 #
 # Foreign Keys
 #

--- a/test/factories/artists.rb
+++ b/test/factories/artists.rb
@@ -14,6 +14,7 @@
 #
 #  index_artists_on_image_id         (image_id) UNIQUE
 #  index_artists_on_normalized_name  (normalized_name)
+#  index_artists_on_updated_at       (updated_at)
 #
 # Foreign Keys
 #

--- a/test/factories/plays.rb
+++ b/test/factories/plays.rb
@@ -11,9 +11,10 @@
 #
 # Indexes
 #
-#  index_plays_on_track_id              (track_id)
-#  index_plays_on_user_id               (user_id)
-#  index_plays_on_user_id_and_track_id  (user_id,track_id)
+#  index_plays_on_track_id                (track_id)
+#  index_plays_on_user_id                 (user_id)
+#  index_plays_on_user_id_and_track_id    (user_id,track_id)
+#  index_plays_on_user_id_and_updated_at  (user_id,updated_at)
 #
 # Foreign Keys
 #

--- a/test/factories/tracks.rb
+++ b/test/factories/tracks.rb
@@ -17,6 +17,7 @@
 #  index_tracks_on_album_id          (album_id)
 #  index_tracks_on_audio_file_id     (audio_file_id) UNIQUE
 #  index_tracks_on_normalized_title  (normalized_title)
+#  index_tracks_on_updated_at        (updated_at)
 #
 # Foreign Keys
 #

--- a/test/models/album_test.rb
+++ b/test/models/album_test.rb
@@ -17,6 +17,7 @@
 #
 #  index_albums_on_image_id          (image_id) UNIQUE
 #  index_albums_on_normalized_title  (normalized_title)
+#  index_albums_on_updated_at        (updated_at)
 #
 # Foreign Keys
 #

--- a/test/models/artist_test.rb
+++ b/test/models/artist_test.rb
@@ -14,6 +14,7 @@
 #
 #  index_artists_on_image_id         (image_id) UNIQUE
 #  index_artists_on_normalized_name  (normalized_name)
+#  index_artists_on_updated_at       (updated_at)
 #
 # Foreign Keys
 #

--- a/test/models/play_test.rb
+++ b/test/models/play_test.rb
@@ -11,9 +11,10 @@
 #
 # Indexes
 #
-#  index_plays_on_track_id              (track_id)
-#  index_plays_on_user_id               (user_id)
-#  index_plays_on_user_id_and_track_id  (user_id,track_id)
+#  index_plays_on_track_id                (track_id)
+#  index_plays_on_user_id                 (user_id)
+#  index_plays_on_user_id_and_track_id    (user_id,track_id)
+#  index_plays_on_user_id_and_updated_at  (user_id,updated_at)
 #
 # Foreign Keys
 #

--- a/test/models/track_test.rb
+++ b/test/models/track_test.rb
@@ -17,6 +17,7 @@
 #  index_tracks_on_album_id          (album_id)
 #  index_tracks_on_audio_file_id     (audio_file_id) UNIQUE
 #  index_tracks_on_normalized_title  (normalized_title)
+#  index_tracks_on_updated_at        (updated_at)
 #
 # Foreign Keys
 #

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -102,6 +102,14 @@ module SignInHelper
   end
 end
 
+module EtagHelper
+  def construct_etag(query, page: nil, per_page: nil)
+    cache_key = ActiveSupport::Cache.expand_cache_key([query.cache_key_with_version, page, per_page].compact)
+    "W/\"#{ActiveSupport::Digest.hexdigest(cache_key)}\""
+  end
+end
+
 class ActionDispatch::IntegrationTest
+  include EtagHelper
   include SignInHelper
 end


### PR DESCRIPTION
This adds custom logic for etag to our most used controllers, so that we can reduce the amount of work if the server has to do. Since browsers already keep a cache of requests, this should provide a big speed-up for web users (if they are requesting unchanged data). I'm not sure if the other clients will automatically benefit from this, or need to add logic to handle this themselves.

## Logic for stale data
We use rails' caching mechanism to calculate an etag for the whole collection. Internally `.cache_key_with_version` gets called on the scope. This looks at the SQL query that would be executed, the total number of items in the scope, the max updated_at in the collection. This means that the etag will be different if an item is added, updated or deleted.
The etag also includes the page number/amount of items per page, so two different requests will always include a different etag. (I'm not sure if this is strictly necessary, but it shouldn't hurt either?)

We only provide the `etag` header and don't provide a `Last-Modified` header, since that date wouldn't change if an item is deleted.

I added `touch: true` to the association that are included in the response, to avoid situations were we would update the associated object without changing `updated_at` on the "primary" object.

## Performance
This provides a big speed up for the controllers if the right `If-None-Match` header is send, since we don't need to fetch the actual data from the DB, and don't need to serialize the objects to json.
For most of these controllers the time spent by rails is reduced to ±10ms (on my local machine, in some casual observations - the real speed here will probably depend on the amount of records in the collection). Since a full reload of our data often sends a torrent of simultaneous requests, the duration measured by the client can still be a lot more (but that is no different from today).

## Further improvements
Since the etag is based on the total collection in each controller, a client could add the following logic to reduce the amount of work they have to do:
* Store the etag of the first page
* Request the first page with that etag
* Stop requesting pages if that first page matches

We could also base the etag on the actual page of items instead of the total collection, but that would mean that clients would still need to request all pages to verify that an item wasn't deleted somewhere. The current approach means that one change in one object would invalidate all pages. Since we often sort by `id: :desc` adding an item would always invalidate all pages (and deleting an item all pages from the one that contained that item onwards)

## Questions
* Do we want to add this to all index actions for consistency? I now only added this to the controllers which we used the most and often need to send multiple pages of data. I didn't add this to all index actions since we were missing timestamps on a lot of these models (no clue why we don't have those columns for every almost all models)
* Do we want more tests for this? I only added this for `AlbumsController` as an example, but I wouldn't mind adding this for all controllers that were changed. (Or adding tests to verify that changing some association results in a different etag)

- [x] I've added tests relevant to my changes.

<!---
  If you did any manual testing as well, please mention so
  here. Provide instructions so we can reproduce those tests.
  --->
