### PR TITLE
Filter token from being logged

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -3,4 +3,4 @@
 # Configure parameters to be partially matched (e.g. passw matches password) and filtered from the log file.
 # Use this to limit dissemination of sensitive information.
 # See the ActiveSupport::ParameterFilter documentation for supported notations and behaviors.
-Rails.application.config.filter_parameters += %i[passw secret]
+Rails.application.config.filter_parameters += %i[password token]


### PR DESCRIPTION
Noticed while looking at the logs for a change to the android app that the token was in there in clear text, we should probably avoid that :grimacing: 
