### PR TITLE
Revert "Bump brakeman from 7.1.0 to 7.1.1"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,7 +82,7 @@ GEM
     bigdecimal (3.3.1)
     bootsnap (1.18.6)
       msgpack (~> 1.2)
-    brakeman (7.1.1)
+    brakeman (7.1.0)
       racc
     builder (3.3.0)
     concurrent-ruby (1.3.5)

--- a/gemset.nix
+++ b/gemset.nix
@@ -194,6 +194,14 @@
   };
   brakeman = {
     dependencies = ["racc"];
+    groups = ["development"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1bs8bm3qj2wfy5h1bp8qi1d3vjw5zabhnq5rr288802kbakhiixv";
+      type = "gem";
+    };
+    version = "7.1.0";
   };
   builder = {
     groups = ["default" "development" "test"];


### PR DESCRIPTION
Reverts accentor/api#834

Didn't pay attention to the failed gemset again...