### PR TITLE
Fix simplecov deprecation warnings

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,9 +1,9 @@
 require 'simplecov'
 SimpleCov.start 'rails' do
   enable_coverage :branch
-  add_filter 'vendor'
-  add_group 'Policies', 'app/policies'
-  add_group 'Serializers', 'app/serializers'
+  skip 'vendor'
+  group 'Policies', 'app/policies'
+  group 'Serializers', 'app/serializers'
 end
 
 if ENV['CI'].present?


### PR DESCRIPTION
Noticed this recently when looking at the test output.