### PR TITLE
Override `ActiveStorage::DirectUploadsController` to disable direct uploads

### DIFF
--- a/app/controllers/active_storage/direct_uploads_controller.rb
+++ b/app/controllers/active_storage/direct_uploads_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# We override the builtin direct uploads controller, to disable this feature entirely
+class ActiveStorage::DirectUploadsController < ActiveStorage::BaseController
+  def create
+    head :forbidden
+  end
+end

--- a/test/controllers/active_storage/direct_uploads_controller_test.rb
+++ b/test/controllers/active_storage/direct_uploads_controller_test.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ActiveStorage::DirectUploadsControllerTest < ActionDispatch::IntegrationTest
+  test 'should return forbidden' do
+    post rails_direct_uploads_path
+
+    assert_response :forbidden
+  end
+end


### PR DESCRIPTION
This PR closes a potential vector for abuse: `ActiveStorage` sets up a direct uploads controller by default which is open to the public to upload files on the server. Since we don't use direct uploads, we should just return forbidden for these requests. (smth smth, this should really be a config setting that is off by default. If we would use direct uploads, we'd still only allow this for signed in users)

We could probably also just block this in nginx with the flake

- [x] I've added tests relevant to my changes.

<!---
  If you did any manual testing as well, please mention so
  here. Provide instructions so we can reproduce those tests.
  --->
