### PR TITLE
Bump bundled postgresql in devshell to latest stable

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -66,7 +66,7 @@
               (pkgs.lib.lowPrio gems.wrappedRuby)
               pkgs.ffmpeg
               pkgs.nixpkgs-fmt
-              pkgs.postgresql_14
+              pkgs.postgresql_18
             ];
             env = [
               {


### PR DESCRIPTION
This will need a re-init of your dev DB. Data can be saved through a pg_dumpall + psql as described in https://www.postgresql.org/docs/18/upgrading.html#UPGRADING-VIA-PGDUMPALL.