### PR TITLE
Do a policy check at the resource level before any other callbacks

### DIFF
--- a/app/controllers/albums_controller.rb
+++ b/app/controllers/albums_controller.rb
@@ -57,7 +57,7 @@ class AlbumsController < ApplicationController
   private
 
   def set_album
-    @album = Album.find(params.expect(:id))
+    @album = policy_scope(Album).find(params.expect(:id))
     authorize @album
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -62,10 +62,10 @@ class ApplicationController < ActionController::API
 
   def user_not_authorized(exc)
     status = current_user.present? ? :forbidden : :unauthorized
-    render json: { errors: [{ model: exc.policy.record.model_name.singular, type: status, action: exc.query }] }, status:
+    render json: { errors: [{ model: exc.record.model_name.singular, type: status, action: action_name }] }, status:
   end
 
   def model_not_found(exc)
-    render json: { errors: [{ model: exc.model.downcase, type: :not_found }] }, status: :not_found
+    render json: { errors: [{ model: exc.model.underscore, type: :not_found }] }, status: :not_found
   end
 end

--- a/app/controllers/artists_controller.rb
+++ b/app/controllers/artists_controller.rb
@@ -57,7 +57,7 @@ class ArtistsController < ApplicationController
   private
 
   def set_artist
-    @artist = Artist.find(params.expect(:id))
+    @artist = policy_scope(Artist).find(params.expect(:id))
     authorize @artist
   end
 

--- a/app/controllers/auth_tokens_controller.rb
+++ b/app/controllers/auth_tokens_controller.rb
@@ -15,7 +15,8 @@ class AuthTokensController < ApplicationController
   end
 
   def create
-    authorize AuthToken
+    # We don't use pundit in this action since it's configured to require a user
+    skip_authorization
 
     user = User.find_by(name: params[:name])
     unless user.try(:authenticate, params[:password])
@@ -25,7 +26,7 @@ class AuthTokensController < ApplicationController
 
     @auth_token = AuthToken.new(
       { user_agent: request.headers[:'user-agent'] }
-          .merge(params[:auth_token].present? ? permitted_attributes(AuthToken) : {})
+          .merge(params[:auth_token].present? ? params.expect(auth_token: %i[user_agent application]) : {})
           .merge(user:)
     )
 
@@ -43,7 +44,7 @@ class AuthTokensController < ApplicationController
   private
 
   def set_auth_token
-    @auth_token = AuthToken.find(params.expect(:id))
+    @auth_token = policy_scope(AuthToken).find(params.expect(:id))
     authorize @auth_token
   end
 

--- a/app/controllers/codec_conversions_controller.rb
+++ b/app/controllers/codec_conversions_controller.rb
@@ -42,7 +42,7 @@ class CodecConversionsController < ApplicationController
   private
 
   def set_codec_conversion
-    @codec_conversion = CodecConversion.find(params.expect(:id))
+    @codec_conversion = policy_scope(CodecConversion).find(params.expect(:id))
     authorize @codec_conversion
   end
 

--- a/app/controllers/codecs_controller.rb
+++ b/app/controllers/codecs_controller.rb
@@ -40,7 +40,7 @@ class CodecsController < ApplicationController
   private
 
   def set_codec
-    @codec = Codec.find(params.expect(:id))
+    @codec = policy_scope(Codec).find(params.expect(:id))
     authorize @codec
   end
 

--- a/app/controllers/cover_filenames_controller.rb
+++ b/app/controllers/cover_filenames_controller.rb
@@ -32,7 +32,7 @@ class CoverFilenamesController < ApplicationController
   private
 
   def set_cover_filename
-    @cover_filename = CoverFilename.find(params.expect(:id))
+    @cover_filename = policy_scope(CoverFilename).find(params.expect(:id))
     authorize @cover_filename
   end
 

--- a/app/controllers/genres_controller.rb
+++ b/app/controllers/genres_controller.rb
@@ -51,7 +51,7 @@ class GenresController < ApplicationController
   private
 
   def set_genre
-    @genre = Genre.find(params.expect(:id))
+    @genre = policy_scope(Genre).find(params.expect(:id))
     authorize @genre
   end
 

--- a/app/controllers/image_types_controller.rb
+++ b/app/controllers/image_types_controller.rb
@@ -40,7 +40,7 @@ class ImageTypesController < ApplicationController
   private
 
   def set_image_type
-    @image_type = ImageType.find(params.expect(:id))
+    @image_type = policy_scope(ImageType).find(params.expect(:id))
     authorize @image_type
   end
 

--- a/app/controllers/labels_controller.rb
+++ b/app/controllers/labels_controller.rb
@@ -51,7 +51,7 @@ class LabelsController < ApplicationController
   private
 
   def set_label
-    @label = Label.find(params.expect(:id))
+    @label = policy_scope(Label).find(params.expect(:id))
     authorize @label
   end
 

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -32,7 +32,7 @@ class LocationsController < ApplicationController
   private
 
   def set_location
-    @location = Location.find(params.expect(:id))
+    @location = policy_scope(Location).find(params.expect(:id))
     authorize @location
   end
 

--- a/app/controllers/playlists_controller.rb
+++ b/app/controllers/playlists_controller.rb
@@ -46,7 +46,7 @@ class PlaylistsController < ApplicationController
   private
 
   def set_playlist
-    @playlist = Playlist.find(params.expect(:id))
+    @playlist = policy_scope(Playlist).find(params.expect(:id))
     authorize @playlist
   end
 

--- a/app/controllers/rescans_controller.rb
+++ b/app/controllers/rescans_controller.rb
@@ -27,7 +27,7 @@ class RescansController < ApplicationController
   private
 
   def set_rescan
-    @rescan = RescanRunner.find(params.expect(:id))
+    @rescan = policy_scope(RescanRunner).find(params.expect(:id))
     authorize @rescan
   end
 

--- a/app/controllers/tracks_controller.rb
+++ b/app/controllers/tracks_controller.rb
@@ -83,6 +83,11 @@ class TracksController < ApplicationController
 
   private
 
+  def set_track
+    @track = policy_scope(Track).find(params.expect(:id))
+    authorize @track
+  end
+
   def send_file_with_range(path, mimetype)
     Rack::Files.new(nil).serving(request, path).tap do |(status, headers, body)|
       self.status = status
@@ -93,11 +98,6 @@ class TracksController < ApplicationController
       response.headers['accept-ranges'] = 'bytes'
       response.headers['content-type'] = mimetype
     end
-  end
-
-  def set_track
-    @track = Track.find(params.expect(:id))
-    authorize @track
   end
 
   def transformed_attributes

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -47,7 +47,7 @@ class UsersController < ApplicationController
   private
 
   def set_user
-    @user = User.find(params.expect(:id))
+    @user = policy_scope(User).find(params.expect(:id))
     authorize @user
   end
 

--- a/app/policies/album_policy.rb
+++ b/app/policies/album_policy.rb
@@ -5,33 +5,13 @@ class AlbumPolicy < ApplicationPolicy
     end
   end
 
-  def index?
-    user.present?
-  end
-
-  def show?
-    index?
-  end
-
-  def create?
-    user&.moderator?
-  end
-
-  def update?
-    user
-  end
-
-  def destroy?
-    create?
-  end
-
-  def destroy_empty?
-    create?
-  end
-
-  def merge?
-    create?
-  end
+  def index? = true
+  def show? = true
+  def create? = user.moderator?
+  def update? = true
+  def destroy? = create?
+  def destroy_empty? = create?
+  def merge? = create?
 
   def permitted_attributes
     if user.moderator?

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -4,6 +4,8 @@ class ApplicationPolicy
   def initialize(user, record)
     @user = user
     @record = record
+
+    raise Pundit::NotAuthorizedError.new(message: 'must be logged in', policy: self, record:) if user.blank?
   end
 
   class Scope
@@ -12,6 +14,8 @@ class ApplicationPolicy
     def initialize(user, scope)
       @user = user
       @scope = scope
+
+      raise Pundit::NotAuthorizedError.new(message: 'must be logged in', policy: self, record: scope.none.model) if user.blank?
     end
   end
 end

--- a/app/policies/artist_policy.rb
+++ b/app/policies/artist_policy.rb
@@ -5,33 +5,13 @@ class ArtistPolicy < ApplicationPolicy
     end
   end
 
-  def index?
-    user.present?
-  end
-
-  def show?
-    index?
-  end
-
-  def create?
-    user&.moderator?
-  end
-
-  def update?
-    user
-  end
-
-  def destroy?
-    create?
-  end
-
-  def destroy_empty?
-    create?
-  end
-
-  def merge?
-    create?
-  end
+  def index? = true
+  def show? = true
+  def create? = user.moderator?
+  def update? = true
+  def destroy? = create?
+  def destroy_empty? = create?
+  def merge? = create?
 
   def permitted_attributes
     if user.moderator?

--- a/app/policies/auth_token_policy.rb
+++ b/app/policies/auth_token_policy.rb
@@ -5,23 +5,7 @@ class AuthTokenPolicy < ApplicationPolicy
     end
   end
 
-  def index?
-    user.present?
-  end
-
-  def show?
-    user.present? && record.user == user
-  end
-
-  def create?
-    true
-  end
-
-  def destroy?
-    show?
-  end
-
-  def permitted_attributes
-    %i[user_agent application]
-  end
+  def index? = true
+  def show? = record.user == user
+  def destroy? = show?
 end

--- a/app/policies/codec_conversion_policy.rb
+++ b/app/policies/codec_conversion_policy.rb
@@ -5,25 +5,11 @@ class CodecConversionPolicy < ApplicationPolicy
     end
   end
 
-  def index?
-    user.present?
-  end
-
-  def show?
-    index?
-  end
-
-  def create?
-    user&.moderator?
-  end
-
-  def update?
-    create?
-  end
-
-  def destroy?
-    create?
-  end
+  def index? = true
+  def show? = true
+  def create? = user.moderator?
+  def update? = create?
+  def destroy? = create?
 
   def permitted_attributes
     %i[name ffmpeg_params resulting_codec_id]

--- a/app/policies/codec_policy.rb
+++ b/app/policies/codec_policy.rb
@@ -5,25 +5,11 @@ class CodecPolicy < ApplicationPolicy
     end
   end
 
-  def index?
-    user.present?
-  end
-
-  def show?
-    index?
-  end
-
-  def create?
-    user&.moderator?
-  end
-
-  def update?
-    create?
-  end
-
-  def destroy?
-    create?
-  end
+  def index? = true
+  def show? = true
+  def create? = user.moderator?
+  def update? = create?
+  def destroy? = create?
 
   def permitted_attributes_for_create
     %i[mimetype extension]

--- a/app/policies/cover_filename_policy.rb
+++ b/app/policies/cover_filename_policy.rb
@@ -1,25 +1,26 @@
 class CoverFilenamePolicy < ApplicationPolicy
   class Scope < Scope
+    def initialize(user, scope)
+      super
+
+      raise Pundit::NotAuthorizedError.new(message: 'must be at least moderator', policy: self, record: scope.none.model) unless user.moderator?
+    end
+
     def resolve
       scope.all
     end
   end
 
-  def index?
-    user&.moderator?
+  def initialize(user, record)
+    super
+
+    raise Pundit::NotAuthorizedError.new(message: 'must be at least moderator', policy: self, record:) unless user.moderator?
   end
 
-  def show?
-    user&.moderator?
-  end
-
-  def create?
-    user&.moderator?
-  end
-
-  def destroy?
-    user&.moderator?
-  end
+  def index? = true
+  def show? = true
+  def create? = true
+  def destroy? = true
 
   def permitted_attributes
     [:filename]

--- a/app/policies/genre_policy.rb
+++ b/app/policies/genre_policy.rb
@@ -5,33 +5,13 @@ class GenrePolicy < ApplicationPolicy
     end
   end
 
-  def index?
-    user.present?
-  end
-
-  def show?
-    index?
-  end
-
-  def create?
-    user&.moderator?
-  end
-
-  def update?
-    create?
-  end
-
-  def destroy?
-    create?
-  end
-
-  def destroy_empty?
-    create?
-  end
-
-  def merge?
-    create?
-  end
+  def index? = true
+  def show? = true
+  def create? = user.moderator?
+  def update? = create?
+  def destroy? = create?
+  def destroy_empty? = create?
+  def merge? = create?
 
   def permitted_attributes
     [:name]

--- a/app/policies/image_type_policy.rb
+++ b/app/policies/image_type_policy.rb
@@ -5,25 +5,11 @@ class ImageTypePolicy < ApplicationPolicy
     end
   end
 
-  def index?
-    user.present?
-  end
-
-  def show?
-    index?
-  end
-
-  def create?
-    user&.moderator?
-  end
-
-  def update?
-    create?
-  end
-
-  def destroy?
-    create?
-  end
+  def index? = true
+  def show? = true
+  def create? = user.moderator?
+  def update? = create?
+  def destroy? = create?
 
   def permitted_attributes_for_create
     %i[mimetype extension]

--- a/app/policies/label_policy.rb
+++ b/app/policies/label_policy.rb
@@ -5,33 +5,13 @@ class LabelPolicy < ApplicationPolicy
     end
   end
 
-  def index?
-    user.present?
-  end
-
-  def show?
-    index?
-  end
-
-  def create?
-    user&.moderator?
-  end
-
-  def update?
-    create?
-  end
-
-  def destroy?
-    create?
-  end
-
-  def destroy_empty?
-    create?
-  end
-
-  def merge?
-    create?
-  end
+  def index? = true
+  def show? = true
+  def create? = user.moderator?
+  def update? = create?
+  def destroy? = create?
+  def destroy_empty? = create?
+  def merge? = create?
 
   def permitted_attributes
     [:name]

--- a/app/policies/location_policy.rb
+++ b/app/policies/location_policy.rb
@@ -1,25 +1,26 @@
 class LocationPolicy < ApplicationPolicy
   class Scope < Scope
+    def initialize(user, scope)
+      super
+
+      raise Pundit::NotAuthorizedError.new(message: 'must be at least moderator', policy: self, record: scope.none.model) unless user.moderator?
+    end
+
     def resolve
       scope.all
     end
   end
 
-  def index?
-    user&.moderator?
+  def initialize(user, record)
+    super
+
+    raise Pundit::NotAuthorizedError.new(message: 'must be at least moderator', policy: self, record:) unless user.moderator?
   end
 
-  def show?
-    user&.moderator?
-  end
-
-  def create?
-    user&.moderator?
-  end
-
-  def destroy?
-    user&.moderator?
-  end
+  def index? = true
+  def show? = true
+  def create? = true
+  def destroy? = true
 
   def permitted_attributes
     [:path]

--- a/app/policies/play_policy.rb
+++ b/app/policies/play_policy.rb
@@ -5,17 +5,9 @@ class PlayPolicy < ApplicationPolicy
     end
   end
 
-  def index?
-    user.present?
-  end
-
-  def create?
-    user.present?
-  end
-
-  def stats?
-    user.present?
-  end
+  def index? = true
+  def create? = true
+  def stats? = true
 
   def permitted_attributes
     %i[track_id played_at]

--- a/app/policies/playlist_policy.rb
+++ b/app/policies/playlist_policy.rb
@@ -5,29 +5,12 @@ class PlaylistPolicy < ApplicationPolicy
     end
   end
 
-  def index?
-    user.present?
-  end
-
-  def show?
-    user.present? && (!record.secret? || user.id == record.user_id)
-  end
-
-  def create?
-    user.present?
-  end
-
-  def update?
-    user.present? && (record.shared? || record.user_id == user.id)
-  end
-
-  def destroy?
-    update?
-  end
-
-  def add_item?
-    update?
-  end
+  def index? = true
+  def show? = !record.secret? || user.id == record.user_id
+  def create? = true
+  def update? = record.shared? || record.user_id == user.id
+  def destroy? = update?
+  def add_item? = update?
 
   def permitted_attributes
     [:name, :description, :playlist_type, { item_ids: [] }, :access]

--- a/app/policies/rescan_runner_policy.rb
+++ b/app/policies/rescan_runner_policy.rb
@@ -1,23 +1,24 @@
 class RescanRunnerPolicy < ApplicationPolicy
   class Scope < Scope
+    def initialize(user, scope)
+      super
+
+      raise Pundit::NotAuthorizedError.new(message: 'must be at least moderator', policy: self, record: scope.none.model) unless user.moderator?
+    end
+
     def resolve
-      scope.all if user&.moderator?
+      scope.all
     end
   end
 
-  def index?
-    user&.moderator?
+  def initialize(user, record)
+    super
+
+    raise Pundit::NotAuthorizedError.new(message: 'must be at least moderator', policy: self, record:) unless user.moderator?
   end
 
-  def show?
-    user&.moderator?
-  end
-
-  def start?
-    user&.moderator?
-  end
-
-  def start_all?
-    user&.moderator?
-  end
+  def index? = true
+  def show? = true
+  def start? = true
+  def start_all? = true
 end

--- a/app/policies/track_policy.rb
+++ b/app/policies/track_policy.rb
@@ -5,41 +5,15 @@ class TrackPolicy < ApplicationPolicy
     end
   end
 
-  def index?
-    user.present?
-  end
-
-  def show?
-    index?
-  end
-
-  def create?
-    user&.moderator?
-  end
-
-  def update?
-    user
-  end
-
-  def destroy?
-    create?
-  end
-
-  def destroy_empty?
-    create?
-  end
-
-  def audio?
-    index?
-  end
-
-  def download?
-    audio?
-  end
-
-  def merge?
-    create?
-  end
+  def index? = true
+  def show? = true
+  def create? = user.moderator?
+  def update? = true
+  def destroy? = create?
+  def destroy_empty? = create?
+  def audio? = show?
+  def download? = audio?
+  def merge? = create?
 
   def permitted_attributes
     if user.moderator?

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -5,25 +5,11 @@ class UserPolicy < ApplicationPolicy
     end
   end
 
-  def index?
-    user.present?
-  end
-
-  def show?
-    index?
-  end
-
-  def create?
-    user&.admin?
-  end
-
-  def update?
-    user == record || user&.admin?
-  end
-
-  def destroy?
-    update?
-  end
+  def index? = true
+  def show? = true
+  def create? = user.admin?
+  def update? = user == record || create?
+  def destroy? = update?
 
   def permitted_attributes
     if user.admin?

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -72,26 +72,26 @@
     {
       "warning_type": "File Access",
       "warning_code": 16,
-      "fingerprint": "f903737fb470236fa01012f7c9278cf768fa5d69c2f4d0e6c8aa340181bd87c3",
+      "fingerprint": "d439371cf78ad33abe21c560d60e2a8e53e227083fc0f4f9633df03049f1cb5f",
       "check_name": "SendFile",
-      "message": "Model attribute used in file name",
+      "message": "Parameter value used in file name",
       "file": "app/controllers/tracks_controller.rb",
       "line": 75,
       "link": "https://brakemanscanner.org/docs/warning_types/file_access/",
-      "code": "send_file(Track.find(params.expect(:id)).audio_file.full_path)",
+      "code": "send_file(policy_scope(Track).find(params.expect(:id)).audio_file.full_path)",
       "render_path": null,
       "location": {
         "type": "method",
         "class": "TracksController",
         "method": "download"
       },
-      "user_input": "Track.find(params.expect(:id)).audio_file.full_path",
-      "confidence": "Medium",
+      "user_input": "params.expect(:id)",
+      "confidence": "Weak",
       "cwe_id": [
         22
       ],
       "note": "The attribute is not configurable by users, but rather set by the scan job"
     }
   ],
-  "brakeman_version": "8.0.4"
+  "brakeman_version": "8.0.5"
 }

--- a/test/controllers/albums_controller_test.rb
+++ b/test/controllers/albums_controller_test.rb
@@ -39,7 +39,7 @@ class AlbumsControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_response :forbidden
-    assert_includes response.parsed_body['errors'], { 'model' => 'album', 'type' => 'forbidden', 'action' => 'create?' }
+    assert_includes response.parsed_body['errors'], { 'model' => 'album', 'type' => 'forbidden', 'action' => 'create' }
   end
 
   test 'should create album for moderator' do
@@ -230,7 +230,7 @@ class AlbumsControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_response :forbidden
-    assert_includes response.parsed_body['errors'], { 'model' => 'album', 'type' => 'forbidden', 'action' => 'destroy?' }
+    assert_includes response.parsed_body['errors'], { 'model' => 'album', 'type' => 'forbidden', 'action' => 'destroy' }
   end
 
   test 'should destroy album for moderator' do
@@ -253,7 +253,7 @@ class AlbumsControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_response :forbidden
-    assert_includes response.parsed_body['errors'], { 'model' => 'album', 'type' => 'forbidden', 'action' => 'destroy_empty?' }
+    assert_includes response.parsed_body['errors'], { 'model' => 'album', 'type' => 'forbidden', 'action' => 'destroy_empty' }
   end
 
   test 'should destroy empty albums for moderator' do
@@ -282,7 +282,7 @@ class AlbumsControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_response :forbidden
-    assert_includes response.parsed_body['errors'], { 'model' => 'album', 'type' => 'forbidden', 'action' => 'merge?' }
+    assert_includes response.parsed_body['errors'], { 'model' => 'album', 'type' => 'forbidden', 'action' => 'merge' }
   end
 
   test 'should merge albums for moderator' do

--- a/test/controllers/artists_controller_test.rb
+++ b/test/controllers/artists_controller_test.rb
@@ -39,7 +39,7 @@ class ArtistsControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_response :forbidden
-    assert_includes response.parsed_body['errors'], { 'model' => 'artist', 'type' => 'forbidden', 'action' => 'create?' }
+    assert_includes response.parsed_body['errors'], { 'model' => 'artist', 'type' => 'forbidden', 'action' => 'create' }
   end
 
   test 'should create artist for moderator' do
@@ -177,7 +177,7 @@ class ArtistsControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_response :forbidden
-    assert_includes response.parsed_body['errors'], { 'model' => 'artist', 'type' => 'forbidden', 'action' => 'destroy?' }
+    assert_includes response.parsed_body['errors'], { 'model' => 'artist', 'type' => 'forbidden', 'action' => 'destroy' }
   end
 
   test 'should destroy artist for moderator' do
@@ -200,7 +200,7 @@ class ArtistsControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_response :forbidden
-    assert_includes response.parsed_body['errors'], { 'model' => 'artist', 'type' => 'forbidden', 'action' => 'destroy_empty?' }
+    assert_includes response.parsed_body['errors'], { 'model' => 'artist', 'type' => 'forbidden', 'action' => 'destroy_empty' }
   end
 
   test 'should destroy empty artists for moderator (track_artist)' do
@@ -251,7 +251,7 @@ class ArtistsControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_response :forbidden
-    assert_includes response.parsed_body['errors'], { 'model' => 'artist', 'type' => 'forbidden', 'action' => 'merge?' }
+    assert_includes response.parsed_body['errors'], { 'model' => 'artist', 'type' => 'forbidden', 'action' => 'merge' }
   end
 
   test 'should merge artists for moderator' do

--- a/test/controllers/auth_tokens_controller_test.rb
+++ b/test/controllers/auth_tokens_controller_test.rb
@@ -16,6 +16,13 @@ class AuthTokensControllerTest < ActionDispatch::IntegrationTest
     assert_equal expected_etag, headers['etag']
   end
 
+  test 'should not get index for signed-out user' do
+    get auth_tokens_url
+
+    assert_response :unauthorized
+    assert_includes response.parsed_body['errors'], { 'model' => 'auth_token', 'type' => 'unauthorized', 'action' => 'index' }
+  end
+
   test 'should get index and return not modified if etag matches' do
     sign_in_as(@user)
 
@@ -84,6 +91,24 @@ class AuthTokensControllerTest < ActionDispatch::IntegrationTest
     get auth_token_url(auth_token)
 
     assert_response :success
+  end
+
+  test 'should not be allowed to find auth token when signed out' do
+    auth_token = create(:auth_token, user: @user)
+    get auth_token_url(auth_token)
+
+    assert_response :unauthorized
+    assert_includes response.parsed_body['errors'], { 'model' => 'auth_token', 'type' => 'unauthorized', 'action' => 'show' }
+  end
+
+  test 'should not find auth token for other user' do
+    sign_in_as(@user)
+
+    auth_token = create(:auth_token)
+    get auth_token_url(auth_token)
+
+    assert_response :not_found
+    assert_includes response.parsed_body['errors'], { 'model' => 'auth_token', 'type' => 'not_found' }
   end
 
   test 'should destroy auth_token' do

--- a/test/controllers/codec_conversions_controller_test.rb
+++ b/test/controllers/codec_conversions_controller_test.rb
@@ -52,7 +52,7 @@ class CodecConversionsControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_response :forbidden
-    assert_includes response.parsed_body['errors'], { 'model' => 'codec_conversion', 'type' => 'forbidden', 'action' => 'create?' }
+    assert_includes response.parsed_body['errors'], { 'model' => 'codec_conversion', 'type' => 'forbidden', 'action' => 'create' }
   end
 
   test 'should create codec_conversion for moderator' do
@@ -165,7 +165,7 @@ class CodecConversionsControllerTest < ActionDispatch::IntegrationTest
     } }
 
     assert_response :forbidden
-    assert_includes response.parsed_body['errors'], { 'model' => 'codec_conversion', 'type' => 'forbidden', 'action' => 'update?' }
+    assert_includes response.parsed_body['errors'], { 'model' => 'codec_conversion', 'type' => 'forbidden', 'action' => 'update' }
   end
 
   test 'should update codec_conversion for moderator' do
@@ -207,7 +207,7 @@ class CodecConversionsControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_response :forbidden
-    assert_includes response.parsed_body['errors'], { 'model' => 'codec_conversion', 'type' => 'forbidden', 'action' => 'destroy?' }
+    assert_includes response.parsed_body['errors'], { 'model' => 'codec_conversion', 'type' => 'forbidden', 'action' => 'destroy' }
   end
 
   test 'should destroy codec_conversion for moderator' do

--- a/test/controllers/codecs_controller_test.rb
+++ b/test/controllers/codecs_controller_test.rb
@@ -40,7 +40,7 @@ class CodecsControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_response :forbidden
-    assert_includes response.parsed_body['errors'], { 'model' => 'codec', 'type' => 'forbidden', 'action' => 'create?' }
+    assert_includes response.parsed_body['errors'], { 'model' => 'codec', 'type' => 'forbidden', 'action' => 'create' }
   end
 
   test 'should not create codec with missing extension' do
@@ -96,7 +96,7 @@ class CodecsControllerTest < ActionDispatch::IntegrationTest
     patch codec_url(@codec), params: { codec: { mimetype: @codec.mimetype } }
 
     assert_response :forbidden
-    assert_includes response.parsed_body['errors'], { 'model' => 'codec', 'type' => 'forbidden', 'action' => 'update?' }
+    assert_includes response.parsed_body['errors'], { 'model' => 'codec', 'type' => 'forbidden', 'action' => 'update' }
   end
 
   test 'should not update codec when clearing mimetype' do
@@ -130,7 +130,7 @@ class CodecsControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_response :forbidden
-    assert_includes response.parsed_body['errors'], { 'model' => 'codec', 'type' => 'forbidden', 'action' => 'destroy?' }
+    assert_includes response.parsed_body['errors'], { 'model' => 'codec', 'type' => 'forbidden', 'action' => 'destroy' }
   end
 
   test 'should destroy codec for moderator' do

--- a/test/controllers/cover_filenames_controller_test.rb
+++ b/test/controllers/cover_filenames_controller_test.rb
@@ -10,7 +10,7 @@ class CoverFilenamesControllerTest < ActionDispatch::IntegrationTest
     get cover_filenames_url
 
     assert_response :forbidden
-    assert_includes response.parsed_body['errors'], { 'model' => 'cover_filename', 'type' => 'forbidden', 'action' => 'index?' }
+    assert_includes response.parsed_body['errors'], { 'model' => 'cover_filename', 'type' => 'forbidden', 'action' => 'index' }
   end
 
   test 'should get index for moderator' do
@@ -60,7 +60,7 @@ class CoverFilenamesControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_response :forbidden
-    assert_includes response.parsed_body['errors'], { 'model' => 'cover_filename', 'type' => 'forbidden', 'action' => 'create?' }
+    assert_includes response.parsed_body['errors'], { 'model' => 'cover_filename', 'type' => 'forbidden', 'action' => 'create' }
   end
 
   test 'should not create cover_filename with empty filename' do
@@ -97,7 +97,7 @@ class CoverFilenamesControllerTest < ActionDispatch::IntegrationTest
     get cover_filename_url(@cover_filename)
 
     assert_response :forbidden
-    assert_includes response.parsed_body['errors'], { 'model' => 'cover_filename', 'type' => 'forbidden', 'action' => 'show?' }
+    assert_includes response.parsed_body['errors'], { 'model' => 'cover_filename', 'type' => 'forbidden', 'action' => 'show' }
   end
 
   test 'should show cover_filename for moderator' do
@@ -120,7 +120,7 @@ class CoverFilenamesControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_response :forbidden
-    assert_includes response.parsed_body['errors'], { 'model' => 'cover_filename', 'type' => 'forbidden', 'action' => 'destroy?' }
+    assert_includes response.parsed_body['errors'], { 'model' => 'cover_filename', 'type' => 'forbidden', 'action' => 'destroy' }
   end
 
   test 'should destroy cover_filename for moderator' do

--- a/test/controllers/genres_controller_test.rb
+++ b/test/controllers/genres_controller_test.rb
@@ -40,7 +40,7 @@ class GenresControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_response :forbidden
-    assert_includes response.parsed_body['errors'], { 'model' => 'genre', 'type' => 'forbidden', 'action' => 'create?' }
+    assert_includes response.parsed_body['errors'], { 'model' => 'genre', 'type' => 'forbidden', 'action' => 'create' }
   end
 
   test 'should not create genre with empty name' do
@@ -83,7 +83,7 @@ class GenresControllerTest < ActionDispatch::IntegrationTest
     patch genre_url(@genre), params: { genre: { name: @genre.name } }
 
     assert_response :forbidden
-    assert_includes response.parsed_body['errors'], { 'model' => 'genre', 'type' => 'forbidden', 'action' => 'update?' }
+    assert_includes response.parsed_body['errors'], { 'model' => 'genre', 'type' => 'forbidden', 'action' => 'update' }
   end
 
   test 'should not update genre to empty name' do
@@ -115,7 +115,7 @@ class GenresControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_response :forbidden
-    assert_includes response.parsed_body['errors'], { 'model' => 'genre', 'type' => 'forbidden', 'action' => 'destroy?' }
+    assert_includes response.parsed_body['errors'], { 'model' => 'genre', 'type' => 'forbidden', 'action' => 'destroy' }
   end
 
   test 'should destroy genre for moderator' do
@@ -142,7 +142,7 @@ class GenresControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_response :forbidden
-    assert_includes response.parsed_body['errors'], { 'model' => 'genre', 'type' => 'forbidden', 'action' => 'destroy_empty?' }
+    assert_includes response.parsed_body['errors'], { 'model' => 'genre', 'type' => 'forbidden', 'action' => 'destroy_empty' }
   end
 
   test 'should destroy empty genres for moderator' do
@@ -183,7 +183,7 @@ class GenresControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_response :forbidden
-    assert_includes response.parsed_body['errors'], { 'model' => 'genre', 'type' => 'forbidden', 'action' => 'merge?' }
+    assert_includes response.parsed_body['errors'], { 'model' => 'genre', 'type' => 'forbidden', 'action' => 'merge' }
   end
 
   test 'should merge genres for moderator' do

--- a/test/controllers/image_types_controller_test.rb
+++ b/test/controllers/image_types_controller_test.rb
@@ -40,7 +40,7 @@ class ImageTypesControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_response :forbidden
-    assert_includes response.parsed_body['errors'], { 'model' => 'image_type', 'type' => 'forbidden', 'action' => 'create?' }
+    assert_includes response.parsed_body['errors'], { 'model' => 'image_type', 'type' => 'forbidden', 'action' => 'create' }
   end
 
   test 'should not create image_type without extension' do
@@ -95,7 +95,7 @@ class ImageTypesControllerTest < ActionDispatch::IntegrationTest
     patch image_type_url(@image_type), params: { image_type: { mimetype: @image_type.mimetype } }
 
     assert_response :forbidden
-    assert_includes response.parsed_body['errors'], { 'model' => 'image_type', 'type' => 'forbidden', 'action' => 'update?' }
+    assert_includes response.parsed_body['errors'], { 'model' => 'image_type', 'type' => 'forbidden', 'action' => 'update' }
   end
 
   test 'should not update image_type to empty mimetype' do
@@ -127,7 +127,7 @@ class ImageTypesControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_response :forbidden
-    assert_includes response.parsed_body['errors'], { 'model' => 'image_type', 'type' => 'forbidden', 'action' => 'destroy?' }
+    assert_includes response.parsed_body['errors'], { 'model' => 'image_type', 'type' => 'forbidden', 'action' => 'destroy' }
   end
 
   test 'should destroy image_type for moderator' do

--- a/test/controllers/labels_controller_test.rb
+++ b/test/controllers/labels_controller_test.rb
@@ -40,7 +40,7 @@ class LabelsControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_response :forbidden
-    assert_includes response.parsed_body['errors'], { 'model' => 'label', 'type' => 'forbidden', 'action' => 'create?' }
+    assert_includes response.parsed_body['errors'], { 'model' => 'label', 'type' => 'forbidden', 'action' => 'create' }
   end
 
   test 'should not create label with empty name' do
@@ -84,7 +84,7 @@ class LabelsControllerTest < ActionDispatch::IntegrationTest
     patch label_url(@label), params: { label: { name: @label.name } }
 
     assert_response :forbidden
-    assert_includes response.parsed_body['errors'], { 'model' => 'label', 'type' => 'forbidden', 'action' => 'update?' }
+    assert_includes response.parsed_body['errors'], { 'model' => 'label', 'type' => 'forbidden', 'action' => 'update' }
   end
 
   test 'should not update label to empty name' do
@@ -116,7 +116,7 @@ class LabelsControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_response :forbidden
-    assert_includes response.parsed_body['errors'], { 'model' => 'label', 'type' => 'forbidden', 'action' => 'destroy?' }
+    assert_includes response.parsed_body['errors'], { 'model' => 'label', 'type' => 'forbidden', 'action' => 'destroy' }
   end
 
   test 'should destroy label for moderator' do
@@ -143,7 +143,7 @@ class LabelsControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_response :forbidden
-    assert_includes response.parsed_body['errors'], { 'model' => 'label', 'type' => 'forbidden', 'action' => 'destroy_empty?' }
+    assert_includes response.parsed_body['errors'], { 'model' => 'label', 'type' => 'forbidden', 'action' => 'destroy_empty' }
   end
 
   test 'should destroy empty labels for moderator' do
@@ -184,7 +184,7 @@ class LabelsControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_response :forbidden
-    assert_includes response.parsed_body['errors'], { 'model' => 'label', 'type' => 'forbidden', 'action' => 'merge?' }
+    assert_includes response.parsed_body['errors'], { 'model' => 'label', 'type' => 'forbidden', 'action' => 'merge' }
   end
 
   test 'should merge labels for moderator' do

--- a/test/controllers/locations_controller_test.rb
+++ b/test/controllers/locations_controller_test.rb
@@ -10,7 +10,7 @@ class LocationsControllerTest < ActionDispatch::IntegrationTest
     get locations_url
 
     assert_response :forbidden
-    assert_includes response.parsed_body['errors'], { 'model' => 'location', 'type' => 'forbidden', 'action' => 'index?' }
+    assert_includes response.parsed_body['errors'], { 'model' => 'location', 'type' => 'forbidden', 'action' => 'index' }
   end
 
   test 'should get index for moderator' do
@@ -60,7 +60,7 @@ class LocationsControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_response :forbidden
-    assert_includes response.parsed_body['errors'], { 'model' => 'location', 'type' => 'forbidden', 'action' => 'create?' }
+    assert_includes response.parsed_body['errors'], { 'model' => 'location', 'type' => 'forbidden', 'action' => 'create' }
   end
 
   test 'should not create location with empty path' do
@@ -97,7 +97,7 @@ class LocationsControllerTest < ActionDispatch::IntegrationTest
     get location_url(@location)
 
     assert_response :forbidden
-    assert_includes response.parsed_body['errors'], { 'model' => 'location', 'type' => 'forbidden', 'action' => 'show?' }
+    assert_includes response.parsed_body['errors'], { 'model' => 'location', 'type' => 'forbidden', 'action' => 'show' }
   end
 
   test 'should show location for moderator' do
@@ -120,7 +120,7 @@ class LocationsControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_response :forbidden
-    assert_includes response.parsed_body['errors'], { 'model' => 'location', 'type' => 'forbidden', 'action' => 'destroy?' }
+    assert_includes response.parsed_body['errors'], { 'model' => 'location', 'type' => 'forbidden', 'action' => 'destroy' }
   end
 
   test 'should destroy location for moderator' do

--- a/test/controllers/playlists_controller_test.rb
+++ b/test/controllers/playlists_controller_test.rb
@@ -125,7 +125,7 @@ class PlaylistsControllerTest < ActionDispatch::IntegrationTest
     patch playlist_url(@playlist), params: { playlist: { name: 'My playlist' } }
 
     assert_response :forbidden
-    assert_includes response.parsed_body['errors'], { 'model' => 'playlist', 'type' => 'forbidden', 'action' => 'update?' }
+    assert_includes response.parsed_body['errors'], { 'model' => 'playlist', 'type' => 'forbidden', 'action' => 'update' }
   end
 
   test 'should not update secret playlist for different user' do
@@ -133,8 +133,8 @@ class PlaylistsControllerTest < ActionDispatch::IntegrationTest
 
     patch playlist_url(@playlist), params: { playlist: { name: 'My playlist' } }
 
-    assert_response :forbidden
-    assert_includes response.parsed_body['errors'], { 'model' => 'playlist', 'type' => 'forbidden', 'action' => 'update?' }
+    assert_response :not_found
+    assert_includes response.parsed_body['errors'], { 'model' => 'playlist', 'type' => 'not_found' }
   end
 
   test 'should destroy shared playlist for user' do
@@ -153,7 +153,7 @@ class PlaylistsControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_response :forbidden
-    assert_includes response.parsed_body['errors'], { 'model' => 'playlist', 'type' => 'forbidden', 'action' => 'destroy?' }
+    assert_includes response.parsed_body['errors'], { 'model' => 'playlist', 'type' => 'forbidden', 'action' => 'destroy' }
   end
 
   test 'should not destroy secret playlist for different user' do
@@ -163,8 +163,8 @@ class PlaylistsControllerTest < ActionDispatch::IntegrationTest
       delete playlist_url(@playlist)
     end
 
-    assert_response :forbidden
-    assert_includes response.parsed_body['errors'], { 'model' => 'playlist', 'type' => 'forbidden', 'action' => 'destroy?' }
+    assert_response :not_found
+    assert_includes response.parsed_body['errors'], { 'model' => 'playlist', 'type' => 'not_found' }
   end
 
   test 'should not add item if no user' do
@@ -177,7 +177,7 @@ class PlaylistsControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_response :unauthorized
-    assert_includes response.parsed_body['errors'], { 'model' => 'playlist', 'type' => 'unauthorized', 'action' => 'add_item?' }
+    assert_includes response.parsed_body['errors'], { 'model' => 'playlist', 'type' => 'unauthorized', 'action' => 'add_item' }
   end
 
   test 'should add item in shared playlist' do
@@ -213,6 +213,6 @@ class PlaylistsControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_response :forbidden
-    assert_includes response.parsed_body['errors'], { 'model' => 'playlist', 'type' => 'forbidden', 'action' => 'add_item?' }
+    assert_includes response.parsed_body['errors'], { 'model' => 'playlist', 'type' => 'forbidden', 'action' => 'add_item' }
   end
 end

--- a/test/controllers/rescans_controller_test.rb
+++ b/test/controllers/rescans_controller_test.rb
@@ -12,7 +12,7 @@ class RescansControllerTest < ActionDispatch::IntegrationTest
     get rescans_url
 
     assert_response :forbidden
-    assert_includes response.parsed_body['errors'], { 'model' => 'rescan_runner', 'type' => 'forbidden', 'action' => 'index?' }
+    assert_includes response.parsed_body['errors'], { 'model' => 'rescan_runner', 'type' => 'forbidden', 'action' => 'index' }
   end
 
   test 'should get index for moderator' do
@@ -59,7 +59,7 @@ class RescansControllerTest < ActionDispatch::IntegrationTest
     get rescan_url(@runner)
 
     assert_response :forbidden
-    assert_includes response.parsed_body['errors'], { 'model' => 'rescan_runner', 'type' => 'forbidden', 'action' => 'show?' }
+    assert_includes response.parsed_body['errors'], { 'model' => 'rescan_runner', 'type' => 'forbidden', 'action' => 'show' }
   end
 
   test 'should get show for moderator' do
@@ -73,7 +73,7 @@ class RescansControllerTest < ActionDispatch::IntegrationTest
     post rescan_url(@runner)
 
     assert_response :forbidden
-    assert_includes response.parsed_body['errors'], { 'model' => 'rescan_runner', 'type' => 'forbidden', 'action' => 'start?' }
+    assert_includes response.parsed_body['errors'], { 'model' => 'rescan_runner', 'type' => 'forbidden', 'action' => 'start' }
   end
 
   test 'should start rescan' do
@@ -94,7 +94,7 @@ class RescansControllerTest < ActionDispatch::IntegrationTest
     post rescans_url
 
     assert_response :forbidden
-    assert_includes response.parsed_body['errors'], { 'model' => 'rescan_runner', 'type' => 'forbidden', 'action' => 'start_all?' }
+    assert_includes response.parsed_body['errors'], { 'model' => 'rescan_runner', 'type' => 'forbidden', 'action' => 'start_all' }
   end
 
   test 'should start all rescans' do

--- a/test/controllers/tracks_controller_test.rb
+++ b/test/controllers/tracks_controller_test.rb
@@ -63,7 +63,7 @@ class TracksControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_response :forbidden
-    assert_includes response.parsed_body['errors'], { 'model' => 'track', 'type' => 'forbidden', 'action' => 'create?' }
+    assert_includes response.parsed_body['errors'], { 'model' => 'track', 'type' => 'forbidden', 'action' => 'create' }
   end
 
   test 'should not create track without title' do
@@ -189,7 +189,7 @@ class TracksControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_response :forbidden
-    assert_includes response.parsed_body['errors'], { 'model' => 'track', 'type' => 'forbidden', 'action' => 'destroy?' }
+    assert_includes response.parsed_body['errors'], { 'model' => 'track', 'type' => 'forbidden', 'action' => 'destroy' }
   end
 
   test 'should destroy track for moderator' do
@@ -208,7 +208,7 @@ class TracksControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_response :forbidden
-    assert_includes response.parsed_body['errors'], { 'model' => 'track', 'type' => 'forbidden', 'action' => 'destroy_empty?' }
+    assert_includes response.parsed_body['errors'], { 'model' => 'track', 'type' => 'forbidden', 'action' => 'destroy_empty' }
   end
 
   test 'should destroy empty tracks for moderator' do
@@ -235,7 +235,7 @@ class TracksControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_response :forbidden
-    assert_includes response.parsed_body['errors'], { 'model' => 'track', 'type' => 'forbidden', 'action' => 'merge?' }
+    assert_includes response.parsed_body['errors'], { 'model' => 'track', 'type' => 'forbidden', 'action' => 'merge' }
   end
 
   test 'should merge tracks for moderator' do

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -40,7 +40,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_response :forbidden
-    assert_includes response.parsed_body['errors'], { 'model' => 'user', 'type' => 'forbidden', 'action' => 'create?' }
+    assert_includes response.parsed_body['errors'], { 'model' => 'user', 'type' => 'forbidden', 'action' => 'create' }
   end
 
   test 'should not create user without name' do


### PR DESCRIPTION
Expect for the auth callback, of course. This fixes a leak in our policy/resource handling, where a user could know whether a record with a certain ID existed based on the HTTP response.

A similar issue existed for logged-in users for other user's secret records (auth tokens and playlists, in practice). By policy scoping the `find` calls, authorized users will always get a 404 for records they don't have access to, whether that record exists or not.

- [x] I've added tests relevant to my changes. (Well, I've mostly updated the existing tests, to be more clear.)

<!---
  If you did any manual testing as well, please mention so
  here. Provide instructions so we can reproduce those tests.
  --->
