### PR TITLE
Checkout the repository before releasing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v7
       - name: Create release
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
The `gh` utility doesn't run outside of a git repository


