### PR TITLE
Rework our nix setup

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,26 @@
+{ stdenv
+, lib
+, accentor-api-env
+}:
+
+let
+  rootFiles = lib.fileset.fileFilter (file: builtins.elem file.name [ "config.ru" "Gemfile" "Gemfile.lock" "gemset.nix" "Rakefile" ]) ./.;
+  srcFiles = lib.fileset.unions [ rootFiles ./app ./bin ./config ./db ./lib ./public ];
+in
+stdenv.mkDerivation {
+  pname = "accentor-api";
+  version = "0.24.0";
+  src = lib.fileset.toSource { root = ./.; fileset = srcFiles; };
+
+  buildPhase = ''
+    # Compile bootsnap cache
+    ${accentor-api-env}/bin/bundle exec bootsnap precompile --gemfile app/ lib/
+  '';
+
+  installPhase = ''
+    mkdir $out
+    cp -r * $out
+  '';
+
+  passthru.env = accentor-api-env;
+}

--- a/flake.lock
+++ b/flake.lock
@@ -40,24 +40,6 @@
         "type": "github"
       }
     },
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1787135253,
@@ -78,23 +60,7 @@
       "inputs": {
         "bundix": "bundix",
         "devshell": "devshell",
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -2,132 +2,49 @@
   description = "Accentor API";
 
   inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     bundix = {
       url = "github:inscapist/bundix";
       inputs.nixpkgs.follows = "nixpkgs";
     };
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    flake-utils.url = "github:numtide/flake-utils";
     devshell = {
       url = "github:numtide/devshell";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };
 
-  outputs = { self, nixpkgs, bundix, devshell, flake-utils }:
-    flake-utils.lib.eachDefaultSystem (system:
-      let
-        pkgs = import nixpkgs {
-          inherit system;
-          overlays = [
-            devshell.overlays.default
-            (self: super: { inherit bundix; })
-          ];
-        };
-        ruby = pkgs.ruby_4_0;
-        gems = pkgs.bundlerEnv {
-          name = "accentor-api-env";
-          ruby = ruby.override { jemallocSupport = true; };
-          gemfile = ./Gemfile;
-          lockfile = ./Gemfile.lock;
-          gemset = ./gemset.nix;
-          groups = [ "default" "development" "test" "production" ];
-        };
-      in
-      {
-        packages = rec {
-          default = accentor-api;
-          accentor-api = pkgs.stdenv.mkDerivation rec {
-            pname = "accentor-api";
-            version = "0.24.0";
-
-            src = pkgs.lib.cleanSourceWith { filter = name: type: !(builtins.elem name [ ".github" "flake.lock" "flake.nix" ]); src = ./.; name = "source"; };
-
-            buildPhase = ''
-              # Compile bootsnap cache
-              ${gems}/bin/bundle exec bootsnap precompile --gemfile app/ lib/
-            '';
-
-            installPhase = ''
-              mkdir $out
-              cp -r * $out
-            '';
-
-            passthru.env = gems;
-          };
-        };
-
-        devShells = rec {
-          default = accentor-api;
-          accentor-api = pkgs.devshell.mkShell {
-            name = "Accentor API";
-            packages = [
-              gems
-              (pkgs.lib.lowPrio gems.wrappedRuby)
-              pkgs.ffmpeg
-              pkgs.nixpkgs-fmt
-              pkgs.postgresql_18
-            ];
-            env = [
-              {
-                name = "PGDATA";
-                eval = "$PRJ_DATA_DIR/postgres";
-              }
-              {
-                name = "DATABASE_HOST";
-                eval = "$PGDATA";
-              }
-            ];
-            commands = [
-              {
-                name = "pg:setup";
-                category = "database";
-                help = "Setup postgres in project folder";
-                command = ''
-                  initdb --encoding=UTF8 --no-locale --no-instructions -U postgres
-                  echo "listen_addresses = ${"'"}${"'"}" >> $PGDATA/postgresql.conf
-                  echo "unix_socket_directories = '$PGDATA'" >> $PGDATA/postgresql.conf
-                  echo "CREATE USER accentor WITH PASSWORD 'accentor' CREATEDB;" | postgres --single -E postgres
-                '';
-              }
-              {
-                name = "pg:start";
-                category = "database";
-                help = "Start postgres instance";
-                command = ''
-                  [ ! -d $PGDATA ] && pg:setup
-                  pg_ctl -D $PGDATA -U postgres start -l log/postgres.log
-                '';
-              }
-              {
-                name = "pg:stop";
-                category = "database";
-                help = "Stop postgres instance";
-                command = ''
-                  pg_ctl -D $PGDATA -U postgres stop
-                '';
-              }
-              {
-                name = "pg:console";
-                category = "database";
-                help = "Open database console";
-                command = ''
-                  psql --host $PGDATA -U postgres
-                '';
-              }
-              {
-                name = "gems:update";
-                category = "dependencies";
-                help = "Update the `Gemfile.lock` and `gemset.nix` files";
-                command = ''
-                  ${ruby}/bin/bundle lock --add-checksums
-                  ${pkgs.bundix}/bin/bundix
-                '';
-              }
-            ];
-          };
-          deps = pkgs.devshell.mkShell { packages = [ ruby pkgs.bundix ]; };
-        };
-      }
-    );
+  outputs = inputs:
+    let
+      gemsForPkgs = pkgs: pkgs.bundlerEnv {
+        name = "accentor-api-env";
+        ruby = pkgs.ruby_4_0.override { jemallocSupport = true; };
+        gemfile = ./Gemfile;
+        lockfile = ./Gemfile.lock;
+        gemset = ./gemset.nix;
+        groups = [ "default" "development" "test" "production" ];
+      };
+    in
+    {
+      packages = builtins.mapAttrs
+        (system: pkgs':
+          let
+            pkgs = pkgs'.extend (self: super: { bundix = inputs.bundix; });
+          in
+          {
+            accentor-api = pkgs.callPackage ./default.nix { accentor-api-env = gemsForPkgs pkgs; };
+            default = inputs.self.packages.${system}.accentor-api;
+          })
+        inputs.nixpkgs.legacyPackages;
+      devShells = builtins.mapAttrs
+        (system: pkgs':
+          let
+            pkgs = pkgs'.appendOverlays [ (self: super: { bundix = inputs.bundix; }) inputs.devshell.overlays.default ];
+          in
+          {
+            accentor-api = pkgs.callPackage ./shell.nix { accentor-api-env = gemsForPkgs pkgs; };
+            default = inputs.self.devShells.${system}.accentor-api;
+            deps = pkgs.devshell.mkShell { packages = [ (gemsForPkgs pkgs).wrappedRuby pkgs.bundix ]; };
+          })
+        inputs.nixpkgs.legacyPackages;
+    };
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,79 @@
+{ devshell
+, lib
+, accentor-api-env
+, ffmpeg
+, nixpkgs-fmt
+, postgresql_18
+, bundix
+}:
+
+let
+  ruby = accentor-api-env.wrappedRuby;
+in
+devshell.mkShell {
+  name = "Accentor API";
+  packages = [
+    accentor-api-env
+    (lib.lowPrio ruby)
+    ffmpeg
+    nixpkgs-fmt
+    postgresql_18
+  ];
+  env = [
+    {
+      name = "PGDATA";
+      eval = "$PRJ_DATA_DIR/postgres";
+    }
+    {
+      name = "DATABASE_HOST";
+      eval = "$PGDATA";
+    }
+  ];
+  commands = [
+    {
+      name = "pg:setup";
+      category = "database";
+      help = "Setup postgres in project folder";
+      command = ''
+        initdb --encoding=UTF8 --no-locale --no-instructions -U postgres
+        echo "listen_addresses = ${"'"}${"'"}" >> $PGDATA/postgresql.conf
+        echo "unix_socket_directories = '$PGDATA'" >> $PGDATA/postgresql.conf
+        echo "CREATE USER accentor WITH PASSWORD 'accentor' CREATEDB;" | postgres --single -E postgres
+      '';
+    }
+    {
+      name = "pg:start";
+      category = "database";
+      help = "Start postgres instance";
+      command = ''
+        [ ! -d $PGDATA ] && pg:setup
+        pg_ctl -D $PGDATA -U postgres start -l log/postgres.log
+      '';
+    }
+    {
+      name = "pg:stop";
+      category = "database";
+      help = "Stop postgres instance";
+      command = ''
+        pg_ctl -D $PGDATA -U postgres stop
+      '';
+    }
+    {
+      name = "pg:console";
+      category = "database";
+      help = "Open database console";
+      command = ''
+        psql --host $PGDATA -U postgres
+      '';
+    }
+    {
+      name = "gems:update";
+      category = "dependencies";
+      help = "Update the `Gemfile.lock` and `gemset.nix` files";
+      command = ''
+        ${ruby}/bin/bundle lock --add-checksums
+        ${bundix}/bin/bundix
+      '';
+    }
+  ];
+}


### PR DESCRIPTION
Similar to https://github.com/accentor/web/pull/1527.

This PR does the following:
- Gets rid of our dependency on flake-utils. It's not really necessary in modern nix flakes (see also https://nixcademy.com/posts/new-default-nix-flake-template/).
- Moves the package and shell definition to separate files
- Changes the way we filter files in the package source definition (using lib.fileset and an allow list instead of a deny list)