### PR TITLE
Make dependencies job more lightweight

### DIFF
--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -17,11 +17,8 @@ jobs:
         with:
           name: accentor
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-          skipPush: true
       - run: nix build -L --no-link .#accentor-api
       - run: nix build -L --no-link .#accentor-api.env
-      - run: nix eval --json ".#accentor-api.outPath" | sed 's/"\(.*\)"/\1/' | cachix push accentor
-      - run: nix eval --json ".#accentor-api.env.outPath" | sed 's/"\(.*\)"/\1/' | cachix push accentor
   shell:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -37,6 +34,4 @@ jobs:
         with:
           name: accentor
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-          skipPush: true
       - run: nix build -L --no-link .#devShells.$(nix eval --impure --expr "builtins.currentSystem").accentor-api
-      - run: nix eval --json ".#devShells.$(nix eval --impure --expr 'builtins.currentSystem').accentor-api.outPath" | sed 's/"\(.*\)"/\1/' | cachix push accentor

--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -35,3 +35,4 @@ jobs:
           name: accentor
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - run: nix build -L --no-link .#devShells.$(nix eval --impure --expr "builtins.currentSystem").accentor-api
+      - run: nix build -L --no-link .#devShells.$(nix eval --impure --expr "builtins.currentSystem").deps

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -19,6 +19,11 @@ jobs:
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
           nix_path: nixpkgs=https://github.com/NixOS/nixpkgs/archive/refs/heads/nixos-unstable.tar.gz
+      - name: Cachix
+        uses: cachix/cachix-action@v17
+        with:
+          name: accentor
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - name: Run bundix
         run: nix develop .#deps --command bundix
       - uses: stefanzweifel/git-auto-commit-action@v7.2.0

--- a/flake.nix
+++ b/flake.nix
@@ -15,9 +15,10 @@
 
   outputs = inputs:
     let
+      rubyForPkgs = pkgs: pkgs.ruby_4_0.override { jemallocSupport = true; };
       gemsForPkgs = pkgs: pkgs.bundlerEnv {
         name = "accentor-api-env";
-        ruby = pkgs.ruby_4_0.override { jemallocSupport = true; };
+        ruby = rubyForPkgs pkgs;
         gemfile = ./Gemfile;
         lockfile = ./Gemfile.lock;
         gemset = ./gemset.nix;
@@ -43,7 +44,7 @@
           {
             accentor-api = pkgs.callPackage ./shell.nix { accentor-api-env = gemsForPkgs pkgs; };
             default = inputs.self.devShells.${system}.accentor-api;
-            deps = pkgs.devshell.mkShell { packages = [ (gemsForPkgs pkgs).wrappedRuby pkgs.bundix ]; };
+            deps = pkgs.devshell.mkShell { packages = [ (rubyForPkgs pkgs) pkgs.bundix ]; };
           })
         inputs.nixpkgs.legacyPackages;
     };


### PR DESCRIPTION
Because the dependencies job didn't use cachix and used the ruby from the gems, it needed to build Ruby with jemalloc support, which took a long time. This changes the dependencies job to use cachix, and makes sure the deps shell doesn't go through the gemset derivation.